### PR TITLE
Updated version number to match app version number (3.9.0). Altered RXTXPort to use ReentrantReadWriteLock instead of synchronize().

### DIFF
--- a/nrjavaserial/build.xml
+++ b/nrjavaserial/build.xml
@@ -25,7 +25,7 @@
 <!-- maven stuff -->
 <property name="groupId" value="com.neuronrobotics" />
 <property name="artifactId" value="nrjavaserial" />
-<property name="version" value="3.7.7" />
+<property name="version" value="3.9.0" />
 
 <property name="maven-jar" value="${dist.home}/maven/${artifactId}-${version}.jar" />
 <property name="maven-javadoc-jar" value="${dist.home}/maven/${artifactId}-${version}-javadoc.jar" />

--- a/nrjavaserial/pom.xml
+++ b/nrjavaserial/pom.xml
@@ -13,7 +13,7 @@
   <artifactId>nrjavaserial</artifactId>
   <packaging>jar</packaging>
   <name>nrjavaserial</name>
-  <version>3.7.7</version>
+  <version>3.9.0</version>
   <description>Fork of the RXTX library with a focus on ease of use and the ability to embed in other libraries.</description>
   <url>http://code.google.com/p/nrjavaserial/</url>
   <licenses>


### PR DESCRIPTION
Altered IOLocked and IOLockedMutex to use ReentrantReadWriteLock eliminating all synchronize() statements in the port IO methods.  This also eliminates 2 significant timing holes: where a read or write starts before the port is closed and the errant use of the non-atomic boolean closeLock variable.  ReadLocks allow for multiple concurrent ReadLocks but do not allow locking with a WriteLock.  A WriteLock cannot occur if ReadLocks are outstanding.  This is exactly what the authors pre-Java 1.5 were trying to accomplish albeit unsuccessfully.
