### PR TITLE
Allow to add a port candidate to a RXTXCommDriver

### DIFF
--- a/nrjavaserial/src/main/java/gnu/io/RXTXCommDriver.java
+++ b/nrjavaserial/src/main/java/gnu/io/RXTXCommDriver.java
@@ -415,6 +415,20 @@ public class RXTXCommDriver implements CommDriver
 		
 	}
 
+	public boolean addSpecifiedPort(String PortName, int PortType)
+	{
+		if (testRead(PortName, PortType))
+		{
+			CommPortIdentifier.addPortName(PortName,
+				PortType, this);
+			return true;
+		}
+		else
+		{
+			return false;
+		}
+	}
+
 	private void addSpecifiedPorts(String names, int PortType)
 	{
 		final String pathSep = System.getProperty("path.separator", ":");
@@ -426,9 +440,7 @@ public class RXTXCommDriver implements CommDriver
 		{
 			String PortName = tok.nextToken();
 
-			if (testRead(PortName, PortType))
-				CommPortIdentifier.addPortName(PortName,
-					PortType, this);
+			addSpecifiedPort(PortName, PortType);
 		}
 	}
 


### PR DESCRIPTION
See #23

Normally a NoSuchPortException is raised, if you try to get a port identifier for a not commonly used device name.
This change allow us to add device candidates in the code by using the following lines:

<pre>
final RXTXCommDriver rxtxCommDriver;
rxtxCommDriver = new RXTXCommDriver();
rxtxCommDriver.initialize();
if (rxtxCommDriver.addSpecifiedPort(device, CommPortIdentifier.PORT_SERIAL)) {
    CommPortIdentifier.addPortName(device, CommPortIdentifier.PORT_SERIAL, rxtxCommDriver);
}
</pre>

Dit not know, if this is a "good" solution / workaround.

We could also change the internally hold list of names of common ports, ...
But perhaps this list should not be changeable at runtime.
