### PR TITLE
Modified build.xml for building OSGI bundle.

### DIFF
--- a/nrjavaserial/build.xml
+++ b/nrjavaserial/build.xml
@@ -17,7 +17,7 @@
   <property name="compile.debug"       value="true"/>
   <property name="compile.deprecation" value="false"/>
   <property name="compile.optimize"    value="true"/>
-  <property name="compile.target"      value="1.7"/>
+  <property name="compile.target"      value="1.7"/> <!-- anything from 1.4 -->
   <property name="compile.source"      value="${compile.target}"/>
                
   <property name="jar.module" value="${app.name}-${app.version}.jar"/>

--- a/nrjavaserial/build.xml
+++ b/nrjavaserial/build.xml
@@ -1,99 +1,115 @@
 <project name="Neuron Robotics Java Serial" default="deploy" basedir="." xmlns:artifact="antlib:org.apache.maven.artifact.ant">
-
-	<!--<property file="../NRSDK/src/com/neuronrobotics/sdk/config/build.properties"/>-->
-
-  <property name="app.name"      value="nr-java-serial"/>
-  <property name="app.version"      value="3.9.2"/>
-  <property name="app.path"      value="/${app.name}"/>
-  <property name="build.home"    value="${basedir}/build"/>
-  <property name="lib.home"      value="${basedir}/src/main/c/resources"/>
-  <property name="dist.home"     value="${basedir}/target"/>
-  <property name="docs.home"     value="${basedir}/docs"/>
-  <property name="src.home"      value="${basedir}/src/main/java"/>
-	
-	
-  <property name="compile.debug"       value="true"/>
-  <property name="compile.deprecation" value="false"/>
-  <property name="compile.optimize"    value="true"/>
+ 
+  <!--<property file="../NRSDK/src/com/neuronrobotics/sdk/config/build.properties"/>-->
+ 
+  <property name="app.name"    value="nr-java-serial"/>
+  <property name="app.version" value="3.9.3"/>
+  <property name="app.path"    value="/${app.name}"/>
+  <property name="build.home"  value="${basedir}/build"/>
+  <property name="lib.home"    value="${basedir}/src/main/c/resources"/>
+  <property name="dist.home"   value="${basedir}/target"/>
+  <property name="docs.home"   value="${basedir}/docs"/>
+  <property name="src.home"    value="${basedir}/src/main/java"/>
+ 
+  <!-- RXTX version as may be required by external OSGi bundles -->
+  <property name="gnu.io.version" value="2.2.0"/> <!-- ??? -->
 
   <property name="compile.debug"       value="true"/>
   <property name="compile.deprecation" value="false"/>
   <property name="compile.optimize"    value="true"/>
-	
+  <property name="compile.target"      value="1.7"/>
+  <property name="compile.source"      value="${compile.target}"/>
+               
   <property name="jar.module" value="${app.name}-${app.version}.jar"/>
-
+ 
 <!-- maven stuff -->
 <property name="groupId" value="com.neuronrobotics" />
 <property name="artifactId" value="nrjavaserial" />
-<property name="version" value="3.9.2" />
-
+<property name="version" value="3.9.3" />
+ 
 <property name="maven-jar" value="${dist.home}/maven/${artifactId}-${version}.jar" />
 <property name="maven-javadoc-jar" value="${dist.home}/maven/${artifactId}-${version}-javadoc.jar" />
 <property name="maven-sources-jar" value="${dist.home}/maven/${artifactId}-${version}-sources.jar" />
-
+ 
 <property name="maven-snapshots-repository-id" value="sonatype-nexus-snapshots" />
 <property name="maven-snapshots-repository-url" value="https://oss.sonatype.org/content/repositories/snapshots/" />
 <property name="maven-staging-repository-id" value="sonatype-nexus-staging" />
 <property name="maven-staging-repository-url" value="https://oss.sonatype.org/service/local/staging/deploy/maven2/" />
-
+ 
+<!-- OSGi stuff -->
+  <property name="osgi.name" value="nrjavaserial"/>
+  <property name="osgi.jar" value="${dist.home}/osgi/${osgi.name}-${version}.jar" />
+  <property name="osgi.url" value="https://github.com/NeuronRobotics/nrjavaserial/"/>
+  <property name="osgi.description" value="Fork of the RXTX library with a focus on ease of use and the ability to embed in other libraries."/>
+  <property name="osgi.ExportPackage" value="gnu.io;version=&quot;${gnu.io.version}&quot;"/>
+  <property name="osgi.NativeCode" value="
+native/windows/x86_32/libNRJavaSerial.dll;osname=Win32;processor=x86,
+native/windows/x86_64/libNRJavaSerial.dll;osname=Win32;processor=x86-64,
+native/osx/libNRJavaSerial.jnilib;osname=MacOSX,
+native/linux/PPC/libNRJavaSerial.so;osname=Linux;processor=PowerPC,
+native/linux/ARM_A8/libNRJavaSerial.so;native/linux/ARM_A8/libNRJavaSerial_legacy.so;osname=Linux;processor=arm,
+native/linux/x86_32/libNRJavaSerial.so;native/linux/x86_32/libNRJavaSerial_legacy.so;osname=Linux;processor=x86,
+native/linux/x86_64/libNRJavaSerial.so;native/linux/x86_64/libNRJavaSerial_legacy.so;osname=Linux;processor=x86-64"/>
+ 
   <target name="clean"
    description="Delete old build and dist directories">
     <delete dir="${build.home}"/>
     <delete dir="${dist.home}"/>
   </target>
-
+ 
   <target name="prepare" description="Create the file structure for assembly">
     <mkdir  dir="${build.home}"/>
-  	
+               
     <mkdir  dir="${build.home}/lib"/>
-  	
+               
     <copy  todir="${build.home}/lib">
-    	<fileset dir="${lib.home}" includes="**/*"/>
+      <fileset dir="${lib.home}" includes="**/*"/>
     </copy>
   </target>
-
+ 
   <path id="compile.classpath">
     <fileset dir="${lib.home}">
       <include name="*.jar"/>
-    </fileset>  	
+    </fileset>      
   </path>
-	
+               
   <target name="compile" depends="prepare"
    description="Compile Java sources">
     <mkdir    dir="${build.home}"/>
     <javac srcdir="${src.home}"
-			destdir="${build.home}"
-			debug="${compile.debug}"
-			deprecation="${compile.deprecation}"
-			optimize="${compile.optimize}">
-        <classpath refid="compile.classpath"/>
+      destdir="${build.home}"
+      debug="${compile.debug}"
+      deprecation="${compile.deprecation}"
+      target="${compile.target}"
+      source="${compile.source}"
+      optimize="${compile.optimize}">
+    <classpath refid="compile.classpath"/>
     </javac>
-  	
+               
     <copy  todir="${build.home}">
       <fileset dir="${src.home}" excludes="**/*.java"/>
     </copy>
   </target>
-
-  <target name="dist"
-   description="Create binary distribution">
-  	<mkdir dir="${dist.home}/docs/api"/>
-  	
+ 
+  <target name="dist" description="Create binary distribution">
+    <mkdir dir="${dist.home}/docs/api"/>
+               
     <jar jarfile="${dist.home}/nrjavaserial-${app.version}.jar">
       <manifest>
         <attribute name="Sealed" value="false"/>
       </manifest>
       <fileset dir="build">
         <include name="**/*.class"/>
-      	<include name="**/*.png"/>
+        <include name="**/*.png"/>
         <exclude name="test/*.class"/>
       </fileset>
       <fileset dir="${build.home}/lib" includes="**/*" />
     </jar>
-  	
-  </target>	
-
+               
+  </target>         
+ 
   <target name="maven-dist" depends="compile" description="generate the distribution">
-
+ 
     <!-- build the main artifact -->
     <jar jarfile="${maven-jar}" >
        <manifest>
@@ -106,32 +122,52 @@
       </fileset>
       <fileset dir="${build.home}/lib" includes="**/*" />
     </jar>
-
+ 
     <!-- build the javadoc artifact -->
     <javadoc sourcepath="${src.home}" destdir="${dist.home}/javadoc" />
     <jar jarfile="${maven-javadoc-jar}">
       <fileset dir="${dist.home}/javadoc" />
     </jar>
-
+ 
     <!-- build the sources artifact -->
     <jar jarfile="${maven-sources-jar}">
       <fileset dir="${src.home}" />
     </jar>
   </target>
-	
+ 
+  <target name="osgi-dist" depends="clean, prepare, compile" description="generate an OSGi bundle">
+    <jar jarfile="${osgi.jar}" >
+       <manifest>
+        <attribute name="Sealed" value="false"/>
+        <attribute name="Bundle-Description" value="${osgi.description}"/>
+        <attribute name="Bundle-DocURL" value="${osgi.url}"/>
+        <attribute name="Bundle-SymbolicName" value="${osgi.name}"/>
+        <attribute name="Bundle-Version" value="${app.version}"/>
+        <attribute name="Bundle-NativeCode" value="${osgi.NativeCode}"/>
+        <attribute name="Export-Package" value="${osgi.ExportPackage}"/>
+      </manifest>
+      <fileset dir="build">
+        <include name="**/*.class"/>
+        <include name="**/*.png"/>
+        <exclude name="test/*.class"/>
+      </fileset>
+      <fileset dir="${build.home}/lib" includes="**/*" />
+    </jar>
+  </target>
+               
   <target name="javadoc" depends="compile"
    description="Create Javadoc API documentation">
-    
-    <javadoc sourcepath="${src.home}" destdir="${dist.home}/docs/api" packagenames="*" 
-    	source="1.6" splitindex="true" use="true" version="true">
-      <classpath refid="compile.classpath"/> 
+   
+    <javadoc sourcepath="${src.home}" destdir="${dist.home}/docs/api" packagenames="*"
+                source="1.6" splitindex="true" use="true" version="true">
+      <classpath refid="compile.classpath"/>
       <bottom><![CDATA[<script type="text/javascript" src="/googleanalytics.js"></script>]]></bottom>
-   	</javadoc>
+    </javadoc>
   </target>
-
-  <target name="deploy" depends="clean, prepare, compile, dist, javadoc"
+ 
+  <target name="deploy" depends="clean, prepare, compile, dist, javadoc, osgi-dist"
    description="Builds the full deployment" />
-
+ 
   <target name="stage" depends="maven-dist" description="deploy release version to Maven staging repository">
   <!-- sign and deploy the main artifact -->
     <artifact:mvn>
@@ -142,7 +178,7 @@
       <arg value="-Dfile=${maven-jar}" />
       <arg value="-Pgpg" />
     </artifact:mvn>
-
+ 
     <!-- sign and deploy the sources artifact -->
     <artifact:mvn>
       <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
@@ -153,7 +189,7 @@
       <arg value="-Dclassifier=sources" />
       <arg value="-Pgpg" />
     </artifact:mvn>
-
+ 
     <!-- sign and deploy the javadoc artifact -->
     <artifact:mvn>
       <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
@@ -166,3 +202,4 @@
     </artifact:mvn>
   </target>
 </project>
+


### PR DESCRIPTION
Following issue #29, this is a modified version of the Ant build file so that
it produces a bundle that it is “OSGi consistent”, with a valid OSGi manifest.
The modification consists in adding “by hand” the missing manifest properties.

The bundle is produced by a new target “osgi-dist” that generates a file
target/osgi/nrjavaserial-3.9.3.jar, which only differs from the
target/nrjavaserial-3.9.3.jar by the manifest.
This target is added in the default target’s dependencies.
