### PR TITLE
Consistency cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,101 +1,122 @@
-#About
+# About
 
-This is a fork of the RXTX library with a focus on ease of use and the ability to embed in other libraries. 
+This is a fork of the [RXTX library](http://rxtx.qbang.org/) with a focus on
+ease of use and embeddability in other libraries.
 
-##Some of the features we have added##
+## Some of the features we have added
 
-A simplified serial port object called NRSerialPort, see the Wiki for an example...
+* A simplified serial port object called `NRSerialPort`. See below for an
+  example.
 
-Self deployment of native libraries ( all native code is stored inside the jar and deployed at runtime). No more manual install of native code.
+* Self-deployment of native libraries (all native code is stored inside the JAR
+  and deployed at runtime). No more manual installation of native code.
 
-Arm Cortex support (Gumstix)
+* Arm Cortex support (Gumstix).
 
-Android Support (requires a rooted phone to access the serial hardware)
+* Android Support (requires a rooted phone to access the serial hardware).
 
-Single makefile compile (simplifies the compilation of project binaries)
+* Single Makefile compile which simplifies the compilation of project binaries.
 
-Ant build script for jar creation
+* Gradle support for JAR creation.
 
-Removal of partially implemented code to streamline the lib for just serial port access
+* Removal of partially-implemented RXTX code to streamline the library for just
+  serial port access.
 
-Full Eclipse integration, for testing application code against sources.
+* Full Eclipse integration for testing application code against sources.
 
-RFC 2217 support provided by incorporating the jvser library (see http://github.com/archiecobbs/jvser)
+* [RFC 2217](http://tools.ietf.org/html/rfc2217) support provided by
+  incorporating the [jvser library](http://github.com/archiecobbs/jvser).
 
-##And a bunch of bug fixes##
+## And a bunch of bug fixes
 
-Fixed the memory access error that causes OSX to crash the JVM when serial.close() is called
+* Fixed the memory access error that causes OS X to crash the JVM when
+  `serial.close()` is called.
 
-Fixed the windows serial port zombie bind that prevents re-accessing serial ports when exiting on an exception
+* Fixed the Windows serial port zombie bind that prevents re-accessing serial
+  ports when exiting on an exception.
 
-Fixed erroneous printouts of native library mis-match
+* Fixed erroneous printouts of native library mis-match.
 
-#Maven
-```
-<dependency>
-  <groupId>com.neuronrobotics</groupId>
-  <artifactId>nrjavaserial</artifactId>
-  <version>3.11.0</version>
-</dependency>
-```
-#Gradle 
-```
-dependencies {
- compile "com.neuronrobotics:nrjavaserial:3.11.0"
-}
-```
+# Dependency Management
 
+## Maven
 
+    <dependency>
+        <groupId>com.neuronrobotics</groupId>
+        <artifactId>nrjavaserial</artifactId>
+        <version>3.11.0</version>
+    </dependency>
 
-# Building Jar
+## Gradle
 
-Checkout the repository.
+    dependencies {
+        compile "com.neuronrobotics:nrjavaserial:3.11.0"
+    }
 
-$cd nrjavaserial/nrjavaserial
+# Building the JAR
 
-$ant
+1. Checkout the repository.
 
-The ready to deploy .jar file will be found in the target/ directory. 
+        $ git clone https://github.com/NeuronRobotics/nrjavaserial.git
 
-#Building Native Code
+2. Build with Gradle.
 
-Native code is built using the Makefile found in nrjavaserial/nrjavaserial . After the native code is built, the .jar is rebuilt. 
+        $ cd nrjavaserial
+        $ gradle build
 
-$cd nrjavaserial/nrjavaserial/
+The resulting JAR will be found in the `build/libs/` directory.
 
-$make windows #This will build the windows binaries. This will attempt to build the 64 and 32 bit binaries. 
+# Building Native Code
 
-$make wine #This will build the windows binaries on Linux
+Native code is built using the Makefile found in the root of the repository.
+After the native code is built, the JAR is rebuilt.
 
-$make linux #This will attempt to build both the 32 and 64 bit Linux binaries
+    # Build both the 32- and 64-bit Windows binaries.
+    $ make windows
 
-$make linux32 or $make linux64 #This will attempt to build 32 or 64 bit Linux binaries
+    # Build the windows binaries on Linux via Wine.
+    $ make wine
 
-$make arm #This will attempt to build the binaries for all the supported ARM flavors
+    # Build both the 32- and 64-bit Linux x86 binaries.
+    $make linux
 
-$make ppc #This will attempt to build the PPC binaries. 
+    # Build 32- or 64-bit Linux binaries, respectively.
+    $ make linux32
+    $ make linux64
 
-$make osx #This will attempt to build the OSX binaries. 
+    # Build the binaries for all the supported ARM flavors.
+    $ make arm
 
+    # Build the OSX binaries.
+    $ make osx
 
-#Windows Builds
-
-Download mingw64: http://tdm-gcc.tdragon.net/
-
-#This is how to use NRSerialPort objects
-
-NRSerialPort serial = new NRSerialPort("COM3", 115200);                          
-
-serial.connect();
-
-DataInputStream ins = new DataInputStream(serial.getInputStream());
-
-DataOutputStream outs = new DataOutputStream(serial.getOutputStream());
-
-byte b = ins.read();
-
-outs.write(b);
-
-serial.disconnect(); 
+    # Build the PPC binaries.
+    $ make ppc
 
 
+## Building on Windows
+
+You'll need some installation of GCC. We recommend the
+[TDM-GCC](http://tdm-gcc.tdragon.net/) distribution of mingw64-w64.
+
+## Building on OS X
+
+We're pretty big on maintaining backwards compatibility as far as reasonable.
+Our OS X natives target OS X 10.5, so to build them, you'll need an appropriate
+SDK installed. [This StackOverflow answer](http://stackoverflow.com/a/6293605)
+provides pointers for getting the appropriate SDK installed.
+
+# How to use NRSerialPort objects
+
+    String port = "COM3";
+    int baudRate = 115200;
+    NRSerialPort serial = new NRSerialPort(port, baudRate);
+    serial.connect();
+
+    DataInputStream ins = new DataInputStream(serial.getInputStream());
+    DataOutputStream outs = new DataOutputStream(serial.getOutputStream());
+
+    byte b = ins.read();
+    outs.write(b);
+
+    serial.disconnect();

--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,9 @@ task sourcesJar(type: Jar) {
 	from sourceSets.main.allSource
 }
 signing {
+	required {
+		gradle.taskGraph.hasTask("uploadArchives")
+	}
 	sign configurations.archives
 }
 artifacts {

--- a/src/main/c/include/OSX/.gitignore
+++ b/src/main/c/include/OSX/.gitignore
@@ -1,0 +1,4 @@
+CarbonCore
+CoreFoundation
+CoreServices
+IOKit


### PR DESCRIPTION
A few amalgamated cleanups in light of de06e99969c4a31498528ddc84dabc72d6c59812:

* Modify the Gradle build to only attempt archival signing when producing a build for upload. This makes it possible for the typical user to blindly run `gradle build` on a fresh checkout and get a useful result (instead of an error about not having a signatory configured).
* Update the README to reflect that the project is now built by Gradle, including build instructions.
* Don't let symlinks generated as part of the OS X built process leak into source control. Some `.gitignore` somewhere saw to it that they were eliminated from the previous source path, but it's not working now that the source has moved (or got lost in the move, or never worked and I'm misremembering things, or...).