### PR TITLE
Add OSGi metadata to the JAR manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'osgi'
 apply plugin: 'eclipse'
 apply plugin: 'maven'
 apply plugin: 'signing'


### PR DESCRIPTION
Uses the [Gradle OSGi plugin](https://docs.gradle.org/current/userguide/osgi_plugin.html) to accomplish what (I think) @kaikreuzer and @cbareau-Orange were trying to achieve with Maven in #29 and #31.

@madhephaestus, if this is cool with you, I'm fine with not making a release specifically for this. I'm going to try to take a look at #6/#22/#36 in the next day or so and IMHO this is the sort of thing that could be rolled into a release along with something else.