### PR TITLE
Factories to create SerialPort

### DIFF
--- a/src/main/java/gnu/io/NRSerialPort.java
+++ b/src/main/java/gnu/io/NRSerialPort.java
@@ -56,7 +56,7 @@ public class NRSerialPort
 
         try
         {
-        	serial = this.serialPortFactory.createSerialPort(port);
+        	serial = this.serialPortFactory.createSerialPort(port, SerialPort.class);
             serial.setSerialPortParams(getBaud(), SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
             setConnected(true);
         }

--- a/src/main/java/gnu/io/NRSerialPort.java
+++ b/src/main/java/gnu/io/NRSerialPort.java
@@ -223,8 +223,21 @@ public class NRSerialPort
     }
 
 
-    public SerialPort getSerialPortInstance()
+    /**
+     * @deprecated please use {@link #getSerialPort()} as the return type can be another implementation.
+     * @return
+     */
+    @Deprecated
+    public RXTXPort getSerialPortInstance()
     {
-        return serial;
+        return (RXTXPort) serial;
+    }
+    /**
+     * Gets the {@link SerialPort} instance.
+     * This will return null until {@link #connect()} is successfully called.
+     * @return The {@link SerialPort} instance or null.
+     */
+    public SerialPort getSerialPort() {
+    	return serial;
     }
 }

--- a/src/main/java/gnu/io/NoSuchPortException.java
+++ b/src/main/java/gnu/io/NoSuchPortException.java
@@ -67,13 +67,16 @@ package gnu.io;
 @SuppressWarnings("serial")
 public class NoSuchPortException extends Exception
 {
-	NoSuchPortException( String str )
+	public NoSuchPortException( String str )
 	{
 		super( str );
 	}
 	public NoSuchPortException()
 	{
 		super();
+	}
+	public NoSuchPortException(String message, Throwable cause) {
+		super(message, cause);
 	}
 }
 

--- a/src/main/java/gnu/io/UnsupportedCommOperationException.java
+++ b/src/main/java/gnu/io/UnsupportedCommOperationException.java
@@ -84,4 +84,8 @@ public class UnsupportedCommOperationException extends Exception
 	{
 		super( str );
 	}
+	
+	public UnsupportedCommOperationException(String message, Throwable cause) {
+		super(message, cause);
+	}
 }

--- a/src/main/java/gnu/io/factory/DefaultSerialPortFactory.java
+++ b/src/main/java/gnu/io/factory/DefaultSerialPortFactory.java
@@ -17,8 +17,8 @@ public class DefaultSerialPortFactory implements SerialPortFactory {
 	 * @see gnu.io.factory.SerialPortFactory#createSerialPort(java.lang.String)
 	 */
 	@Override
-	public SerialPort createSerialPort(String portName) throws PortInUseException, NoSuchPortException, UnsupportedCommOperationException{
-		SerialPortCreator portCreator = this.portRegistry.getPortCreatorForPortName(portName);
+	public <T extends SerialPort> T createSerialPort(String portName, Class<T> expectedClass) throws PortInUseException, NoSuchPortException, UnsupportedCommOperationException{
+		SerialPortCreator<T> portCreator = this.portRegistry.getPortCreatorForPortName(portName, expectedClass);
 		if(portCreator != null) {
 			return portCreator.createPort(portName);
 		}

--- a/src/main/java/gnu/io/factory/DefaultSerialPortFactory.java
+++ b/src/main/java/gnu/io/factory/DefaultSerialPortFactory.java
@@ -1,0 +1,28 @@
+package gnu.io.factory;
+
+import gnu.io.NoSuchPortException;
+import gnu.io.PortInUseException;
+import gnu.io.SerialPort;
+import gnu.io.UnsupportedCommOperationException;
+
+public class DefaultSerialPortFactory implements SerialPortFactory {
+
+	private SerialPortRegistry portRegistry;
+	
+	public DefaultSerialPortFactory() {
+		this.portRegistry = new SerialPortRegistry();
+	}
+	
+	/* (non-Javadoc)
+	 * @see gnu.io.factory.SerialPortFactory#createSerialPort(java.lang.String)
+	 */
+	@Override
+	public SerialPort createSerialPort(String portName) throws PortInUseException, NoSuchPortException, UnsupportedCommOperationException{
+		SerialPortCreator portCreator = this.portRegistry.getPortCreatorForPortName(portName);
+		if(portCreator != null) {
+			return portCreator.createPort(portName);
+		}
+		throw new NoSuchPortException(portName + " can not be opened.");
+	}
+	
+}

--- a/src/main/java/gnu/io/factory/RFC2217PortCreator.java
+++ b/src/main/java/gnu/io/factory/RFC2217PortCreator.java
@@ -1,0 +1,54 @@
+package gnu.io.factory;
+
+import java.net.URI;
+import java.net.UnknownHostException;
+
+import gnu.io.NoSuchPortException;
+import gnu.io.PortInUseException;
+import gnu.io.SerialPort;
+import gnu.io.UnsupportedCommOperationException;
+import gnu.io.rfc2217.TelnetSerialPort;
+
+public class RFC2217PortCreator implements SerialPortCreator{
+
+	private final static String PROTOCOL = "rfc2217";
+	
+	@Override
+	public boolean isApplicable(String portName) {
+		try {
+			URI uri = URI.create(portName);
+			return uri.getScheme().equalsIgnoreCase(PROTOCOL);
+		} catch(Throwable t) {
+			return false;
+		}
+	}
+
+	/**
+	 * @throws UnsupportedCommOperationException if connection to the remote serial port fails.
+	 * @throws NoSuchPortException if the host does not exist.
+	 */
+	@Override
+	public SerialPort createPort(String portName)
+			throws NoSuchPortException, UnsupportedCommOperationException, PortInUseException {
+		 URI url = URI.create(portName);
+	      try
+	      {
+	        TelnetSerialPort telnetSerialPort = new TelnetSerialPort();
+	        telnetSerialPort.getTelnetClient().connect(url.getHost(), url.getPort());
+	        return telnetSerialPort;
+	      }
+	      catch(UnknownHostException e) {
+	    	  throw new NoSuchPortException("Host "+url.getHost()+" not available", e);
+	      }
+	      catch (Exception e)
+	      {
+	    	  throw new UnsupportedCommOperationException("Unable to establish remote connection to serial port "+portName, e);
+	      }
+	}
+
+	@Override
+	public String getProtocol() {
+		return PROTOCOL;
+	}
+
+}

--- a/src/main/java/gnu/io/factory/RFC2217PortCreator.java
+++ b/src/main/java/gnu/io/factory/RFC2217PortCreator.java
@@ -5,19 +5,21 @@ import java.net.UnknownHostException;
 
 import gnu.io.NoSuchPortException;
 import gnu.io.PortInUseException;
-import gnu.io.SerialPort;
 import gnu.io.UnsupportedCommOperationException;
 import gnu.io.rfc2217.TelnetSerialPort;
 
-public class RFC2217PortCreator implements SerialPortCreator{
+public class RFC2217PortCreator implements SerialPortCreator<TelnetSerialPort> {
 
 	private final static String PROTOCOL = "rfc2217";
 	
 	@Override
-	public boolean isApplicable(String portName) {
+	public boolean isApplicable(String portName, Class<TelnetSerialPort> expectedClass) {
 		try {
-			URI uri = URI.create(portName);
-			return uri.getScheme().equalsIgnoreCase(PROTOCOL);
+			if(expectedClass.isAssignableFrom(TelnetSerialPort.class)) {
+				URI uri = URI.create(portName);
+				return uri.getScheme().equalsIgnoreCase(PROTOCOL);
+			}
+			return false;
 		} catch(Throwable t) {
 			return false;
 		}
@@ -28,7 +30,7 @@ public class RFC2217PortCreator implements SerialPortCreator{
 	 * @throws NoSuchPortException if the host does not exist.
 	 */
 	@Override
-	public SerialPort createPort(String portName)
+	public TelnetSerialPort createPort(String portName)
 			throws NoSuchPortException, UnsupportedCommOperationException, PortInUseException {
 		 URI url = URI.create(portName);
 	      try

--- a/src/main/java/gnu/io/factory/RxTxPortCreator.java
+++ b/src/main/java/gnu/io/factory/RxTxPortCreator.java
@@ -4,18 +4,17 @@ import gnu.io.CommPortIdentifier;
 import gnu.io.NoSuchPortException;
 import gnu.io.PortInUseException;
 import gnu.io.RXTXPort;
-import gnu.io.SerialPort;
 import gnu.io.UnsupportedCommOperationException;
 
-public class RxTxPortCreator implements SerialPortCreator {
+public class RxTxPortCreator implements SerialPortCreator<RXTXPort> {
 
 	@Override
-	public boolean isApplicable(String portName) {
-		return true;
+	public boolean isApplicable(String portName, Class<RXTXPort> expectedClass) {
+		return expectedClass.isAssignableFrom(RXTXPort.class);
 	}
 
 	@Override
-	public SerialPort createPort(String port) throws NoSuchPortException, UnsupportedCommOperationException, PortInUseException {
+	public RXTXPort createPort(String port) throws NoSuchPortException, UnsupportedCommOperationException, PortInUseException {
         RXTXPort comm = null;
         CommPortIdentifier ident = null;
         if ((System.getProperty("os.name").toLowerCase().indexOf("linux") != -1))

--- a/src/main/java/gnu/io/factory/RxTxPortCreator.java
+++ b/src/main/java/gnu/io/factory/RxTxPortCreator.java
@@ -1,0 +1,54 @@
+package gnu.io.factory;
+
+import gnu.io.CommPortIdentifier;
+import gnu.io.NoSuchPortException;
+import gnu.io.PortInUseException;
+import gnu.io.RXTXPort;
+import gnu.io.SerialPort;
+import gnu.io.UnsupportedCommOperationException;
+
+public class RxTxPortCreator implements SerialPortCreator {
+
+	@Override
+	public boolean isApplicable(String portName) {
+		return true;
+	}
+
+	@Override
+	public SerialPort createPort(String port) throws NoSuchPortException, UnsupportedCommOperationException, PortInUseException {
+        RXTXPort comm = null;
+        CommPortIdentifier ident = null;
+        if ((System.getProperty("os.name").toLowerCase().indexOf("linux") != -1))
+        {
+            // if ( port.toLowerCase().contains("rfcomm".toLowerCase())||
+            // port.toLowerCase().contains("ttyUSB".toLowerCase()) ||
+            // port.toLowerCase().contains("ttyS".toLowerCase())||
+            // port.toLowerCase().contains("ACM".toLowerCase()) ||
+            // port.toLowerCase().contains("Neuron_Robotics".toLowerCase())||
+            // port.toLowerCase().contains("DyIO".toLowerCase())||
+            // port.toLowerCase().contains("NR".toLowerCase())||
+            // port.toLowerCase().contains("FTDI".toLowerCase())||
+            // port.toLowerCase().contains("ftdi".toLowerCase())
+            // ){
+            System.setProperty("gnu.io.rxtx.SerialPorts", port);
+            // }
+        }
+        ident = CommPortIdentifier.getPortIdentifier(port);
+
+        comm = ident.open("NRSerialPort", 2000);
+
+        if (!(comm instanceof RXTXPort))
+        {
+            throw new UnsupportedCommOperationException("Non-serial connections are unsupported.");
+        }
+        comm.enableReceiveTimeout(100);
+        return comm;
+
+	}
+
+	@Override
+	public String getProtocol() {
+		return LOCAL;
+	}
+
+}

--- a/src/main/java/gnu/io/factory/SerialPortCreator.java
+++ b/src/main/java/gnu/io/factory/SerialPortCreator.java
@@ -1,0 +1,34 @@
+package gnu.io.factory;
+
+import gnu.io.NoSuchPortException;
+import gnu.io.PortInUseException;
+import gnu.io.SerialPort;
+import gnu.io.UnsupportedCommOperationException;
+
+public interface SerialPortCreator {
+
+	final static String LOCAL = "local";
+	
+	/**
+	 * Gets whether this {@link SerialPortCreator} is applicable to create and open the given port.
+	 * @param portName The ports name.
+	 * @return Whether the port can be created and opened by this creator.
+	 */
+	public boolean isApplicable(String portName);
+	
+	/**
+	 * Creates the {@link SerialPort} and opens it for communication.
+	 * @param portName The ports name.
+	 * @return The created {@link SerialPort}.
+	 * @throws NoSuchPortException If the serial port does not exist.
+	 * @throws UnsupportedCommOperationException 
+	 * @throws PortInUseException 
+	 */
+	public SerialPort createPort(String portName) throws NoSuchPortException, UnsupportedCommOperationException, PortInUseException;
+	
+	/**
+	 * Gets the protocol type of the Port to create.
+	 * @return The protocol type.
+	 */
+	public String getProtocol();
+}

--- a/src/main/java/gnu/io/factory/SerialPortCreator.java
+++ b/src/main/java/gnu/io/factory/SerialPortCreator.java
@@ -5,7 +5,7 @@ import gnu.io.PortInUseException;
 import gnu.io.SerialPort;
 import gnu.io.UnsupportedCommOperationException;
 
-public interface SerialPortCreator {
+public interface SerialPortCreator<T extends SerialPort> {
 
 	final static String LOCAL = "local";
 	
@@ -14,7 +14,7 @@ public interface SerialPortCreator {
 	 * @param portName The ports name.
 	 * @return Whether the port can be created and opened by this creator.
 	 */
-	public boolean isApplicable(String portName);
+	public boolean isApplicable(String portName, Class<T> epectedClass);
 	
 	/**
 	 * Creates the {@link SerialPort} and opens it for communication.
@@ -24,7 +24,7 @@ public interface SerialPortCreator {
 	 * @throws UnsupportedCommOperationException 
 	 * @throws PortInUseException 
 	 */
-	public SerialPort createPort(String portName) throws NoSuchPortException, UnsupportedCommOperationException, PortInUseException;
+	public T createPort(String portName) throws NoSuchPortException, UnsupportedCommOperationException, PortInUseException;
 	
 	/**
 	 * Gets the protocol type of the Port to create.

--- a/src/main/java/gnu/io/factory/SerialPortFactory.java
+++ b/src/main/java/gnu/io/factory/SerialPortFactory.java
@@ -1,0 +1,24 @@
+package gnu.io.factory;
+
+import java.io.IOException;
+
+import gnu.io.NoSuchPortException;
+import gnu.io.PortInUseException;
+import gnu.io.SerialPort;
+import gnu.io.UnsupportedCommOperationException;
+
+public interface SerialPortFactory {
+
+	/**
+	 * Creates a {@link SerialPort} instance out of the given <code>portName</code>.
+	 * @param portName The port's name to parse out whether to create a serial connection or a remote (rfc2217) connection.
+	 * @return The newly created and opened SerialPort.
+	 * @throws IOException
+	 * @throws PortInUseException
+	 * @throws NoSuchPortException
+	 * @throws UnsupportedCommOperationException
+	 */
+	SerialPort createSerialPort(String portName)
+			throws PortInUseException, NoSuchPortException, UnsupportedCommOperationException;
+
+}

--- a/src/main/java/gnu/io/factory/SerialPortFactory.java
+++ b/src/main/java/gnu/io/factory/SerialPortFactory.java
@@ -12,13 +12,14 @@ public interface SerialPortFactory {
 	/**
 	 * Creates a {@link SerialPort} instance out of the given <code>portName</code>.
 	 * @param portName The port's name to parse out whether to create a serial connection or a remote (rfc2217) connection.
+	 * @param expectedClass The {@link SerialPort} class that is expected to return.
 	 * @return The newly created and opened SerialPort.
 	 * @throws IOException
 	 * @throws PortInUseException
 	 * @throws NoSuchPortException
 	 * @throws UnsupportedCommOperationException
 	 */
-	SerialPort createSerialPort(String portName)
+	<T extends SerialPort> T createSerialPort(String portName, Class<T> expectedClass)
 			throws PortInUseException, NoSuchPortException, UnsupportedCommOperationException;
 
 }

--- a/src/main/java/gnu/io/factory/SerialPortRegistry.java
+++ b/src/main/java/gnu/io/factory/SerialPortRegistry.java
@@ -8,13 +8,13 @@ import gnu.io.SerialPort;
 
 public class SerialPortRegistry {
 
-	private Collection<SerialPortCreator<?>> portCreators;
+	private Collection<SerialPortCreator<? extends SerialPort>> portCreators;
 	
 	public SerialPortRegistry() {
-		this.portCreators = new TreeSet<SerialPortCreator<?>>(new Comparator<SerialPortCreator<?>>() {
+		this.portCreators = new TreeSet<SerialPortCreator<? extends SerialPort>>(new Comparator<SerialPortCreator<? extends SerialPort>>() {
 
 			@Override
-			public int compare(SerialPortCreator<?> o1, SerialPortCreator<?> o2) {
+			public int compare(SerialPortCreator<? extends SerialPort> o1, SerialPortCreator<? extends SerialPort> o2) {
 				if(o1.getProtocol().equals(SerialPortCreator.LOCAL)) {
 					return 1;
 				}
@@ -33,7 +33,7 @@ public class SerialPortRegistry {
 	 * Registers a {@link SerialPortCreator}.
 	 * @param creator
 	 */
-	public void registerSerialPortCreator(SerialPortCreator<?> creator) {
+	public void registerSerialPortCreator(SerialPortCreator<? extends SerialPort> creator) {
 		this.portCreators.add(creator);
 	}
 	

--- a/src/main/java/gnu/io/factory/SerialPortRegistry.java
+++ b/src/main/java/gnu/io/factory/SerialPortRegistry.java
@@ -4,15 +4,17 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.TreeSet;
 
+import gnu.io.SerialPort;
+
 public class SerialPortRegistry {
 
-	private Collection<SerialPortCreator> portCreators;
+	private Collection<SerialPortCreator<?>> portCreators;
 	
 	public SerialPortRegistry() {
-		this.portCreators = new TreeSet<SerialPortCreator>(new Comparator<SerialPortCreator>() {
+		this.portCreators = new TreeSet<SerialPortCreator<?>>(new Comparator<SerialPortCreator<?>>() {
 
 			@Override
-			public int compare(SerialPortCreator o1, SerialPortCreator o2) {
+			public int compare(SerialPortCreator<?> o1, SerialPortCreator<?> o2) {
 				if(o1.getProtocol().equals(SerialPortCreator.LOCAL)) {
 					return 1;
 				}
@@ -31,7 +33,7 @@ public class SerialPortRegistry {
 	 * Registers a {@link SerialPortCreator}.
 	 * @param creator
 	 */
-	public void registerSerialPortCreator(SerialPortCreator creator) {
+	public void registerSerialPortCreator(SerialPortCreator<?> creator) {
 		this.portCreators.add(creator);
 	}
 	
@@ -40,11 +42,12 @@ public class SerialPortRegistry {
 	 * @param portName The port's name.
 	 * @return A found {@link SerialPortCreator} or null if none could be found.
 	 */
-	public SerialPortCreator getPortCreatorForPortName(String portName) {
-		for(SerialPortCreator creator : this.portCreators) {
+	@SuppressWarnings("unchecked")
+	public <T extends SerialPort> SerialPortCreator<T> getPortCreatorForPortName(String portName, Class<T> expectedClass) {
+		for(@SuppressWarnings("rawtypes") SerialPortCreator creator : this.portCreators) {
 			try {
-				if(creator.isApplicable(portName))
-					return creator;
+				if(creator.isApplicable(portName, expectedClass))
+					return (SerialPortCreator<T>) creator;
 			} catch(Exception e) {
 				System.err.println("Error for SerialPortCreator#isApplicable: " + creator.getClass()+"; " + creator.getProtocol() +" -> " + e.getMessage());
 			}

--- a/src/main/java/gnu/io/factory/SerialPortRegistry.java
+++ b/src/main/java/gnu/io/factory/SerialPortRegistry.java
@@ -1,0 +1,54 @@
+package gnu.io.factory;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.TreeSet;
+
+public class SerialPortRegistry {
+
+	private Collection<SerialPortCreator> portCreators;
+	
+	public SerialPortRegistry() {
+		this.portCreators = new TreeSet<SerialPortCreator>(new Comparator<SerialPortCreator>() {
+
+			@Override
+			public int compare(SerialPortCreator o1, SerialPortCreator o2) {
+				if(o1.getProtocol().equals(SerialPortCreator.LOCAL)) {
+					return 1;
+				}
+				if(o2.getProtocol().equals(SerialPortCreator.LOCAL)) {
+					return -1;
+				}
+				return o1.getProtocol().compareTo(o2.getProtocol());
+			}
+		});
+		
+		registerSerialPortCreator(new RxTxPortCreator());
+		registerSerialPortCreator(new RFC2217PortCreator());
+	}
+	
+	/**
+	 * Registers a {@link SerialPortCreator}.
+	 * @param creator
+	 */
+	public void registerSerialPortCreator(SerialPortCreator creator) {
+		this.portCreators.add(creator);
+	}
+	
+	/**
+	 * Gets the best applicable {@link SerialPortCreator} for the given <code>portName</code>
+	 * @param portName The port's name.
+	 * @return A found {@link SerialPortCreator} or null if none could be found.
+	 */
+	public SerialPortCreator getPortCreatorForPortName(String portName) {
+		for(SerialPortCreator creator : this.portCreators) {
+			try {
+				if(creator.isApplicable(portName))
+					return creator;
+			} catch(Exception e) {
+				System.err.println("Error for SerialPortCreator#isApplicable: " + creator.getClass()+"; " + creator.getProtocol() +" -> " + e.getMessage());
+			}
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
Added new factories to create a SerialPort instance.
This is to reduce the dependencies on client side. 
E.g. when used the TelnetSerialPort, a dependency to org.apache.net.telnet was needed.
Additionally it eases the client code.
NRSerialPort also makes use of the factory.
The factory decides which implementation to use by the port name.