### PR TITLE
Added /dev/ttyAMA to known serial ports list for RPi

### DIFF
--- a/src/main/java/gnu/io/NativeResource.java
+++ b/src/main/java/gnu/io/NativeResource.java
@@ -139,7 +139,12 @@ public class NativeResource {
 		if(!resource.canRead())
 			throw new RuntimeException("Cant open JNI file: "+resource.getAbsolutePath());
 		//System.out.println("Loading: "+resource.getAbsolutePath());
-		System.load(resource.getAbsolutePath());
+		try {
+			System.load(resource.getAbsolutePath());
+		} catch(UnsatisfiedLinkError e){
+			System.out.println(e.getMessage());
+			throw e;
+		}
 	}
 
 	private void copyResource(InputStream io, File file) throws IOException {

--- a/src/main/java/gnu/io/RXTXCommDriver.java
+++ b/src/main/java/gnu/io/RXTXCommDriver.java
@@ -626,7 +626,7 @@ public class RXTXCommDriver implements CommDriver
 						"ttyS", // linux Serial Ports
 						"ttySA", // for the IPAQs
 						"ttyUSB", // for USB frobs
-						"ttyAMA0", // Raspberry Pi
+						"ttyAMA", // Raspberry Pi
 						"rfcomm",       // bluetooth serial device
 						"ttyircomm", // linux IrCommdevices (IrDA serial emu)
 						"ttyACM",// linux CDC ACM devices

--- a/src/main/java/gnu/io/RXTXCommDriver.java
+++ b/src/main/java/gnu/io/RXTXCommDriver.java
@@ -626,6 +626,7 @@ public class RXTXCommDriver implements CommDriver
 						"ttyS", // linux Serial Ports
 						"ttySA", // for the IPAQs
 						"ttyUSB", // for USB frobs
+						"ttyAMA0", // Raspberry Pi
 						"rfcomm",       // bluetooth serial device
 						"ttyircomm", // linux IrCommdevices (IrDA serial emu)
 						"ttyACM",// linux CDC ACM devices


### PR DESCRIPTION
Quick addition to ease the use of this library on RPi projects. This just convenience to avoid having to set the property on every launch, and has been successfully tested with the openHAB aleoncean binding.
