### PR TITLE
Make some imports optional

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ jar {
 			"Implementation-Version" : props."app.version",
 			"Implementation-Vendor": "Neuron Robotics Cooperative",
 		)
-		instruction 'Import-Package', '*'
+		instruction 'Import-Package', 'com.sun.jna.platform.win32;resolution:=optional,org.apache.commons.net.telnet;resolution:=optional,*'
 	}
 }
 


### PR DESCRIPTION
Try to solve an issue mentioned in https://github.com/NeuronRobotics/nrjavaserial/pull/98 where the generated MANIFEST.MF has mandatory package-imports for com.sun.jna.platform.win32and org.apache.commons.net.telnet.
Both of them should be optional.