### PR TITLE
Fix optional imports for OSGi

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,17 +38,15 @@ task wrapper(type: Wrapper, description: 'Creates and deploys the Gradle wrapper
 
 repositories {
 	mavenCentral()
-	maven {
-        url "https://jcenter.bintray.com"
-    }
+	jcenter()
 }
 
 dependencies {
 	compile fileTree(dir: 'libs', includes: ['*.jar'])
 	testCompile 'junit:junit:4.12'
 	compile 'commons-net:commons-net:3.3'
-	compile 'net.java.dev.jna:jna:4.2.2'
-	compile 'net.java.dev.jna:jna-platform:4.2.2'
+	compileOnly 'net.java.dev.jna:jna:4.4.0'
+	compileOnly 'net.java.dev.jna:jna-platform:4.4.0'
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ jar {
 			"Implementation-Version" : props."app.version",
 			"Implementation-Vendor": "Neuron Robotics Cooperative",
 		)
-		instruction 'Import-Package', '*'
+		instruction 'Import-Package', 'com.sun.jna.platform.win32;resolution:=optional,org.apache.commons.net.telnet;resolution:=optional,*'
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ jar {
 			"Implementation-Version" : props."app.version",
 			"Implementation-Vendor": "Neuron Robotics Cooperative",
 		)
-		instruction 'Import-Package', 'com.sun.jna.platform.win32;resolution:=optional,org.apache.commons.net.telnet;resolution:=optional,*'
+		instruction 'Import-Package', 'com.sun.jna.platform.win32;resolution:=optional,org.apache.commons.net.telnet;resolution:=optional,!gnu.io*,*'
 	}
 }
 


### PR DESCRIPTION
Follow-up PR related to https://github.com/NeuronRobotics/nrjavaserial/pull/100.
Now the JNA dependency is really optional:
On Windows there is a check if the classes are present and if not available ports are detected using the old behaviour.

The RFC2217 functionality is unchanged and only needs the dependency present when a TelnetSerialPort ist instanciated (on all platforms).