### PR TITLE
Changed both make files to reflect changes needed for current version…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all:
 	echo "Please specify a system: windows wine linux osx"
 	gradle build
 windows:
-	make -C .\src\main\c windowsLocal
+	mingw32-make -C .\src\main\c windowsLocal
 	gradle build
 wine:
 	make -C src/main/c windows

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Native code is built using the Makefile found in the root of the repository.
 After the native code is built, the JAR is rebuilt.
 
     # Build both the 32- and 64-bit Windows binaries.
-    $ make windows
+    $ mingw32-make windows
 
     # Build the windows binaries on Linux via Wine.
     $ make wine

--- a/src/main/c/Makefile
+++ b/src/main/c/Makefile
@@ -54,7 +54,7 @@ LINKBSD64=c++ -m64 -shared
 WINLINKOPT = -shared -Wl,--add-stdcall-alias -DBUILD_DLL
 WINCCOPT = -O3 -Wall -DBUILD_DLL
 #JDKDIR = C:\Program Files\Java\jdk1.6.0_24\include
-JDKDIR = D:/java-32/jdk1.7.0_25/include
+JDKDIR = C:/jdk1.8.0_161/include
 
 WININCLUDE32=-I".\include" -I".\include\target" -I".\include\windows" -I"C:\MinGW\include" -I"$(JDKDIR)" -I"$(JDKDIR)\win32"
 CCWIN32 = wine "C:\MinGW\bin\gcc.exe" $(WININCLUDE32) -m32 $(WINCCOPT)
@@ -69,12 +69,12 @@ LINKWIN64 =wine "C:\MinGW64\bin\gcc.exe" $(WINLINKOPT)
 #Native Windows
 # MINGW32 = C:\MinGW32
 # MINGW64 = C:\MinGW64
-MINGW32 = C:\TDM-GCC-32
+MINGW32 = C:\TDM-GCC-64
 MINGW64 = C:\TDM-GCC-64
 
 WININCLUDE32N=-I".\include" -I".\include\target" -I".\include\windows" -I"$(MINGW32)\include" -I"$(JDKDIR)" -I"$(JDKDIR)/win32"
 CCWIN32N = "$(MINGW32)\bin\gcc.exe" $(WININCLUDE32N) -m32 $(WINCCOPT)
-LINKWIN32N ="$(MINGW32)\bin\gcc.exe" $(WINLINKOPT)
+LINKWIN32N ="$(MINGW32)\bin\gcc.exe" -m32 $(WINLINKOPT)
 
 WININCLUDE64N=-I".\include" -I".\include\target" -I".\include\windows" -I"$(MINGW64)\include" -I"$(JDKDIR)" -I"$(JDKDIR)/win32"
 CCWIN64N = "$(MINGW64)\bin\gcc.exe" $(WININCLUDE64N) -m64 $(WINCCOPT)


### PR DESCRIPTION
Changed both make files to reflect changes needed for current version of TDM-GCC (5.1.0-3) and updated README.md.  TDM-GCC now uses one folder for both the 32 and 64 bit versions and require the -m32 parameter with the link options as well as the make options.   Also, make.exe is now named mingw32-make.exe.  It was also necessary to manually create the folder nrjavaserial\src\main\c\build.