### PR TITLE
registerScannedPorts not working in all cases

### DIFF
--- a/src/main/java/gnu/io/RXTXCommDriver.java
+++ b/src/main/java/gnu/io/RXTXCommDriver.java
@@ -532,7 +532,7 @@ public class RXTXCommDriver implements CommDriver
 		
 		if(osName.toLowerCase().indexOf("windows") != -1 )
 		{
-			boolean useFallback = false;
+			boolean useFallback = true;
 			String[] temp = new String[0];
 			if (isClassPresent("com.sun.jna.platform.win32.Advapi32Util")) {
 				// on windows, we try to get the serial port list from the registry
@@ -543,8 +543,7 @@ public class RXTXCommDriver implements CommDriver
 				}
 				catch (Throwable ex) {
 					if (debug)
-						System.err.println("Error reading the registry to get port list " + ex.getMessage());
-					useFallback = true;
+						System.err.println("Error reading the registry to get port list " + ex.getMessage());					
 				}
 			}
 


### PR DESCRIPTION
If this lib is used in a Windows OS environment and "com.sun.jna.platform.win32.Advapi32Util" is not present the fallback to full scan is not used.