### PR TITLE
Use named threads

### DIFF
--- a/src/main/java/gnu/io/RXTXPort.java
+++ b/src/main/java/gnu/io/RXTXPort.java
@@ -128,6 +128,7 @@ public class RXTXPort extends SerialPort
 
 			MonitorThreadLock = true;
 			monThread = new MonitorThread();
+			monThread.setName("RXTXPortMonitor("+name+")");
 			monThread.start();
 			waitForTheNativeCodeSilly();
 			MonitorThreadAlive=true;
@@ -821,6 +822,7 @@ public class RXTXPort extends SerialPort
 		{
 			MonitorThreadLock = true;
 			monThread = new MonitorThread();
+			monThread.setName("RXTXPortMonitor("+name+")");
 			monThread.start();
 			waitForTheNativeCodeSilly();
 			MonitorThreadAlive=true;


### PR DESCRIPTION
It's a bit easier to debug Java issues when the library properly names threads:

# Karaf 

```
openhab> threads --list
Id  │ Name                                                                                           │ State         │ CPU time │ Usr time
────┼────────────────────────────────────────────────────────────────────────────────────────────────┼───────────────┼──────────┼─────────
1   │ main                                                                                           │ WAITING       │ 372      │ 320
2   │ Reference Handler                                                                              │ WAITING       │ 11       │ 10
3   │ Finalizer                                                                                      │ WAITING       │ 16       │ 10
5   │ Signal Dispatcher                                                                              │ RUNNABLE      │ 1        │ 0
...
245 │ RXTXPortMonitor(/dev/ttyUSB0)                                                                  │ RUNNABLE      │ 19098    │ 3720
```

# Visual VM

![visualvm](https://user-images.githubusercontent.com/12213581/50727645-145f6d00-111e-11e9-8c66-82c455736c15.png)

Fixes #138