### PR TITLE
Fix IllegalMonitorStateException when thread closing port is interrupted

### DIFF
--- a/src/main/java/gnu/io/RXTXPort.java
+++ b/src/main/java/gnu/io/RXTXPort.java
@@ -1094,13 +1094,15 @@ public class RXTXPort extends SerialPort
                                 z.reportln( "RXTXPort:close( " + this.name + " ) leaving"); 
                 } catch( InterruptedException ie ) {
                         // somebody called interrupt() on us
-                        // we obbey and return without without closing the socket
+                        // we obey and return without closing the socket
                         Thread.currentThread().interrupt();
                         return;
                 }
                 finally
                 {
-                    IOLockedMutex.writeLock().unlock();
+                    if (IOLockedMutex.writeLock().isHeldByCurrentThread()) {
+                        IOLockedMutex.writeLock().unlock();
+                    }
                 }
 
 	}


### PR DESCRIPTION
When a thread is closing the port it may not have obtained the `writeLock` when it is interrupted.
So it should only unlock the `writeLock` in the finally clause when the thread is holding that lock.
This fixes an `IllegalMonitorStateException` that would be thrown if the thread does not hold the lock.

An example stacktrace is:

```
java.lang.IllegalMonitorStateException: null
	at java.util.concurrent.locks.ReentrantReadWriteLock$Sync.tryRelease(ReentrantReadWriteLock.java:371) ~[?:1.8.0_111]
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.release(AbstractQueuedSynchronizer.java:1261) ~[?:1.8.0_111]
	at java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.unlock(ReentrantReadWriteLock.java:1131) ~[?:1.8.0_111]
	at gnu.io.RXTXPort.close(RXTXPort.java:1101) ~[nrjavaserial-3.15.0.jar:3.15.0]
```