### PR TITLE
Use SLF4J for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,52 @@ ease of use and embeddability in other libraries.
 	</dependency>
 ```
 
+# Logging
+
+NRJavaSerial uses [the SLF4J API][slf4j] for logging.
+You may already be using a logging framework
+which implements the SLF4J interface,
+such as [Logback Classic][logback].
+If you are, then NRJavaSerial will use it automatically.
+Alternatively, SLF4J provides [bindings][slf4j-bindings]
+to several other popular logging frameworks.
+If you don't have a compatible logging framework
+on your classpath at runtime,
+you'll get these warning messages
+when loading NRJavaSerial:
+
+```
+SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
+SLF4J: Defaulting to no-operation (NOP) logger implementation
+SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
+```
+
+The solution is to introduce a dependency
+on an SLF4J-compatible logging framework
+or an SLF4J binding to the logging framework of your choice.
+
+If you want to suppress or filter log messages from NRJavaSerial,
+you can configure your logging framework accordingly.
+For example,
+this Logback filter suppresses NRJavaSerial messages
+logged at a severity lower than `WARN` (i.e., `DEBUG` and `TRACE`):
+
+```
+<filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+    <evaluator class="ch.qos.logback.classic.boolex.GEventEvaluator">
+        <expression>
+            e.loggerName.startsWith("gnu.io.")
+                &amp;&amp; e.level.toInt() &lt; WARN.toInt()</expression>
+    </evaluator>
+    <onMatch>DENY</onMatch>
+    <onMismatch>NEUTRAL</onMismatch>
+</filter>
+```
+
+[slf4j]: http://www.slf4j.org/
+[logback]: https://logback.qos.ch/
+[slf4j-bindings]: http://www.slf4j.org/manual.html#swapping
+
 # Building the JAR
 
 1. Checkout the repository.

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ repositories {
 dependencies {
 	compile fileTree(dir: 'libs', includes: ['*.jar'])
 	testCompile 'junit:junit:4.12'
+	testRuntimeOnly 'ch.qos.logback:logback-classic:1.2.3'
+	compile 'org.slf4j:slf4j-api:1.7.30'
 	compile 'commons-net:commons-net:3.7.2'
 	compileOnly 'net.java.dev.jna:jna:4.4.0'
 	compileOnly 'net.java.dev.jna:jna-platform:4.4.0'

--- a/src/main/c/Makefile
+++ b/src/main/c/Makefile
@@ -69,7 +69,7 @@ export LD = $(CC)
 # We want to link objects into a shared library.
 export LDFLAGS ?= -fPIC -shared
 
-export objects := fixup.o fuserImp.o SerialImp.o
+export objects := fixup.o fuserImp.o SerialImp.o slf4j.o
 export lib_type := so
 
 define NO_TARGET_PLATFORM_SPECIFIED
@@ -217,7 +217,7 @@ ppc:
 # Requires a macOS host.
 osx: export CFLAGS += -I$(JAVA_HOME)/include/darwin -arch x86_64
 osx: export LDFLAGS := -arch x86_64 -dynamiclib -framework JavaVM -framework IOKit -framework CoreFoundation
-osx: export objects := fuserImp.o SerialImp.o
+osx: export objects := fuserImp.o SerialImp.o slf4j.o
 osx: export platform := osx
 osx: export lib_type := jnilib
 osx:

--- a/src/main/c/include/SerialImp.h
+++ b/src/main/c/include/SerialImp.h
@@ -356,15 +356,6 @@ printf("%8li sec : %8li usec\n", enow.tv_sec - snow.tv_sec, enow.tv_sec - snow.t
 #define report_time_end( ) {}
 #endif /* DEBUG_TIMING && ! WIN32 */
 
-/* #define TRACE */
-#ifdef TRACE
-#define ENTER(x) report("entering "x" \n");
-#define LEAVE(x) report("leaving "x" \n");
-#else
-#define ENTER(x)
-#define LEAVE(x)
-#endif /* TRACE */
-
 /* allow people to override the directories */
 /* #define USER_LOCK_DIRECTORY "/home/tjarvi/1.5/build" */
 #ifdef USER_LOCK_DIRECTORY
@@ -477,10 +468,6 @@ size_t get_java_var( JNIEnv *, jobject, char *, char * );
 jboolean is_interrupted( struct event_info_struct * );
 int send_event(struct event_info_struct *, jint, int );
 void dump_termios(char *,struct termios *);
-void report_verbose(char *);
-void report_error(char *);
-void report_warning(char *);
-void report(char *);
 void throw_java_exception( JNIEnv *, char *, char *, char * );
 int lock_device( const char * );
 void unlock_device( const char * );

--- a/src/main/c/include/slf4j.h
+++ b/src/main/c/include/slf4j.h
@@ -1,0 +1,177 @@
+/*-------------------------------------------------------------------------
+|   RXTX License v 2.1 - LGPL v 2.1 + Linking Over Controlled Interface.
+|   RXTX is a native interface to serial ports in java.
+|   Copyright 1997-2009 by Trent Jarvi tjarvi@qbang.org and others who
+|   actually wrote it.  See individual source files for more information.
+|
+|   A copy of the LGPL v 2.1 may be found at
+|   http://www.gnu.org/licenses/lgpl.txt on March 4th 2007.  A copy is
+|   here for your convenience.
+|
+|   This library is free software; you can redistribute it and/or
+|   modify it under the terms of the GNU Lesser General Public
+|   License as published by the Free Software Foundation; either
+|   version 2.1 of the License, or (at your option) any later version.
+|
+|   This library is distributed in the hope that it will be useful,
+|   but WITHOUT ANY WARRANTY; without even the implied warranty of
+|   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+|   Lesser General Public License for more details.
+|
+|   An executable that contains no derivative of any portion of RXTX, but
+|   is designed to work with RXTX by being dynamically linked with it,
+|   is considered a "work that uses the Library" subject to the terms and
+|   conditions of the GNU Lesser General Public License.
+|
+|   The following has been added to the RXTX License to remove
+|   any confusion about linking to RXTX.   We want to allow in part what
+|   section 5, paragraph 2 of the LGPL does not permit in the special
+|   case of linking over a controlled interface.  The intent is to add a
+|   Java Specification Request or standards body defined interface in the
+|   future as another exception but one is not currently available.
+|
+|   http://www.fsf.org/licenses/gpl-faq.html#LinkingOverControlledInterface
+|
+|   As a special exception, the copyright holders of RXTX give you
+|   permission to link RXTX with independent modules that communicate with
+|   RXTX solely through the Sun Microsytems CommAPI interface version 2,
+|   regardless of the license terms of these independent modules, and to copy
+|   and distribute the resulting combined work under terms of your choice,
+|   provided that every copy of the combined work is accompanied by a complete
+|   copy of the source code of RXTX (the version of RXTX used to produce the
+|   combined work), being distributed under the terms of the GNU Lesser General
+|   Public License plus this exception.  An independent module is a
+|   module which is not derived from or based on RXTX.
+|
+|   Note that people who make modified versions of RXTX are not obligated
+|   to grant this special exception for their modified versions; it is
+|   their choice whether to do so.  The GNU Lesser General Public License
+|   gives permission to release a modified version without this exception; this
+|   exception also makes it possible to release a modified version which
+|   carries forward this exception.
+|
+|   You should have received a copy of the GNU Lesser General Public
+|   License along with this library; if not, write to the Free
+|   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+|   All trademarks belong to their respective owners.
+--------------------------------------------------------------------------*/
+
+/**
+ * \file slf4j.h
+ *
+ * \brief Functions to enable JNI code to log via SLF4J.
+ */
+
+#ifndef SLF4J_H
+#define SLF4J_H
+
+#include <jni.h>
+
+/**
+ * \brief The log levels used by SLF4J.
+ */
+typedef enum LogLevel
+{
+	LOG_ERROR,
+	LOG_WARN,
+	LOG_INFO,
+	LOG_DEBUG,
+	LOG_TRACE,
+	LOG_LEVELS
+} LogLevel;
+
+/** \brief Trace-level log to denote entering a function. */
+#define ENTER(x) slf4j_log(LOG_TRACE, "entering " x)
+/** \brief Trace-level log to denote leaving a function. */
+#define LEAVE(x) slf4j_log(LOG_TRACE, "leaving " x)
+
+/**
+ * \brief Log a ERROR-level message through SLF4J.
+ *
+ * \param [in] msg the message to log
+ * \see slf4j_log() for prerequisites
+ */
+#define report_error(msg) slf4j_log(LOG_ERROR, msg)
+
+/**
+ * \brief Log a WARN-level message through SLF4J.
+ *
+ * \param [in] msg the message to log
+ * \see slf4j_log() for prerequisites
+ */
+#define report_warning(msg) slf4j_log(LOG_WARN, msg)
+
+/**
+ * \brief Log a DEBUG-level message through SLF4J.
+ *
+ * \param [in] msg the message to log
+ * \see slf4j_log() for prerequisites
+ */
+#define report(msg) slf4j_log(LOG_DEBUG, msg)
+
+/**
+ * \brief Log a TRACE-level message through SLF4J.
+ *
+ * \param [in] msg the message to log
+ * \see slf4j_log() for prerequisites
+ */
+#define report_verbose(msg) slf4j_log(LOG_TRACE, msg)
+
+/**
+ * \brief Log a message through SLF4J from within the scope of a JNI call.
+ *
+ * On entering a JNI method, the user _must_ call either slf4j_setup_instance()
+ * or slf4j_setup_static() before any logging calls. This includes logging
+ * calls performed by other functions called by the JNI function, so it's best
+ * to always call the appropriate setup function even if you don't think you're
+ * going to be doing any logging yourself.
+ *
+ * \param [in] level the level at which to log
+ * \param [in] msg the message to log
+ */
+void slf4j_log(LogLevel level, const char *msg);
+
+/**
+ * \brief Reconfigure the SLF4J logging context for the current thread based on
+ * the given Java object instance.
+ *
+ * Determines the class of the given object, then calls slf4j_setup_static().
+ * See the documentation of that function for details.
+ *
+ * \param [in] env the JNI environment
+ * \param [in] obj an object whose class has a static logger instance
+ */
+void slf4j_setup_instance(JNIEnv *env, jobject jobj);
+
+/**
+ * \brief Reconfigure the SLF4J logging context for the current thread based on
+ * the given Java class.
+ *
+ * Expects that the given class will have a static field named `log` which
+ * holds an instance of `org.slf4j.Logger`.
+ *
+ * This populates a thread-local variable with the JNI environment and class
+ * reference, so that those two parameters don't need to be passed into every
+ * function for logging to be possible. That context information is retained
+ * until overwritten by a subsequent call to slf4j_setup_instance() or
+ * slf4j_setup_static(), or until it is explicitly wiped by slf4j_teardown().
+ *
+ * \param [in] env the JNI environment
+ * \param [in] jclazz a Java class which has a static logger instance
+ * \see slf4j_teardown() for information on when and where it should be called
+ */
+void slf4j_setup_static(JNIEnv *env, jclass jclazz);
+
+/**
+ * \brief Tears down/forgets the SLF4J logging context for the current thread.
+ *
+ * If your native code only runs when called from Java – you don't have any
+ * threads or signal handlers which may run outside of a JNI context – then you
+ * don't need to worry about this. On the other hand, if you have code which
+ * might run outside of the scope of a JNI call, and which may try to call
+ * slf4j_log(), then just as you call one of the two setup functions when
+ * entering every JNI method, you should call this before leaving them.
+ */
+void slf4j_teardown();
+
+#endif /* SLF4J_H */

--- a/src/main/c/src/SerialImp.c
+++ b/src/main/c/src/SerialImp.c
@@ -768,7 +768,7 @@ JNIEXPORT jint JNICALL RXTXPort(open)(
 	if( configure_port( fd ) ) goto fail;
 	(*env)->ReleaseStringUTFChars( env, jstr, filename );
 	sprintf( message, "open: fd returned is %i\n", fd );
-	report( message );
+	report_verbose( message );
 	LEAVE( "RXTXPort:open" );
 	report_time_end( );
 	return (jint)fd;
@@ -814,7 +814,7 @@ JNIEXPORT void JNICALL RXTXPort(nativeClose)( JNIEnv *env,
 		report_warning("nativeClose(): Close not detecting thread pid");
 		return;
 	}
-	report("<nativeClose: pid\n");
+	report_verbose("nativeClose: pid\n");
 
 	/*
 		UNLOCK is one of three functions defined in SerialImp.h
@@ -827,15 +827,14 @@ JNIEXPORT void JNICALL RXTXPort(nativeClose)( JNIEnv *env,
 	ENTER( "RXTXPort:nativeClose" );
 	if (fd > 0)
 	{
-		//report_warning("nativeClose: discarding remaining data (tcflush)\n");
-		report("nativeClose: discarding remaining data (tcflush)\n");
+		report_verbose("nativeClose: discarding remaining data (tcflush)\n");
 		/* discard any incoming+outgoing data not yet read/sent */
 		tcflush(fd, TCIOFLUSH);
 		int x=0;
  		do {
 
  			//report_warning("nativeClose: Attempting to close\n");
-			report("nativeClose:  calling close\n");
+			report_verbose("nativeClose:  calling close\n");
 			result=localClose(fd);
 			//report_warning("nativeClose: Close OK\n");
 			x++;
@@ -852,9 +851,9 @@ JNIEXPORT void JNICALL RXTXPort(nativeClose)( JNIEnv *env,
 		//report_warning("nativeClose(): Close not detecting File Descriptor");
 	}
 	//report_warning("nativeClose() Attempt OK\n");
-	report("nativeClose: Delete jclazz\n");
+	report_verbose("nativeClose: Delete jclazz\n");
 	(*env)->DeleteLocalRef( env, jclazz );
-	report("nativeClose: release filename\n");
+	report_verbose("nativeClose: release filename\n");
 	(*env)->ReleaseStringUTFChars( env, jstr, filename );
 	LEAVE( "RXTXPort:nativeClose" );
 	report_time_end( );
@@ -1494,11 +1493,11 @@ int init_threads( struct event_info_struct *eis )
 	eis->drain_tid = tid;
 	eis->drain_loop_running = 1;
 #endif /* TIOCSERGETLSR */
-	report("init_threads: get eis\n");
+	report_verbose("init_threads: get eis\n");
 	jeis  = (*eis->env)->GetFieldID( eis->env, eis->jclazz, "eis", "J" );
-	report("init_threads: set eis\n");
+	report_verbose("init_threads: set eis\n");
 	(*eis->env)->SetLongField(eis->env, *eis->jobj, jeis, ( size_t ) eis );
-	report("init_threads:  stop\n");
+	report_verbose("init_threads:  stop\n");
 	report_time_end( );
 	return( 1 );
 }
@@ -1637,7 +1636,7 @@ JNIEXPORT void JNICALL RXTXPort(writeArray)( JNIEnv *env,
 		if(result >0){
 			total += result;
 		}
-		report("writeArray()\n");
+		report_verbose("writeArray()\n");
 	}  while ( ( total < count ) && (result < 0 && errno==EINTR ) );
 	if( result < 0 )
 	{
@@ -2023,7 +2022,7 @@ JNIEXPORT void JNICALL RXTXPort(setDSR)( JNIEnv *env,
 	else result &= ~TIOCM_DSR;
 	ioctl( fd, TIOCMSET, &result );
 	sprintf( message, "setDSR( %i )\n", state );
-	report( message );
+	report_verbose( message );
 	LEAVE( "RXTXPort:setDSR()" );
 	return;
 }
@@ -2081,7 +2080,7 @@ JNIEXPORT void JNICALL RXTXPort(setDTR)( JNIEnv *env,
 	else result &= ~TIOCM_DTR;
 	ioctl( fd, TIOCMSET, &result );
 	sprintf( message, "setDTR( %i )\n", state );
-	report( message );
+	report_verbose( message );
 	LEAVE( "RXTXPort:setDTR" );
 	return;
 }
@@ -3983,7 +3982,7 @@ int has_line_status_register_access( int fd )
 		return(1);
 	}
 #endif /* TIOCSERGETLSR */
-	report( "has_line_status_register_acess: Port does not support TIOCSERGETLSR\n" );
+	report_verbose( "has_line_status_register_acess: Port does not support TIOCSERGETLSR\n" );
 	return( 0 );
 }
 
@@ -4380,7 +4379,7 @@ JNIEXPORT void JNICALL RXTXPort(eventLoop)( JNIEnv *env, jobject jobj )
 			/* nothing goes between this call and select */
 			if( eis.closing )
 			{
-				report("eventLoop: got interrupt\n");
+				report_verbose("eventLoop interrupted");
 				finalize_threads( &eis );
 				finalize_event_info_struct( &eis );
 				LEAVE("eventLoop");
@@ -5117,7 +5116,7 @@ JNIEXPORT void JNICALL RXTXPort(interruptEventLoop)(JNIEnv *env,
 	}
 	index->closing = 1;
 #endif
-	report("interruptEventLoop: interrupted\n");
+	report_verbose("InterruptEventLoop interrupted");
 }
 
 /*----------------------------------------------------------

--- a/src/main/c/src/SerialImp.c
+++ b/src/main/c/src/SerialImp.c
@@ -153,6 +153,7 @@
 extern int errno;
 
 #include "SerialImp.h"
+#include "slf4j.h"
 
 JavaVM *javaVM = NULL;
 
@@ -260,6 +261,8 @@ JNIEXPORT void JNICALL RXTXPort(Initialize)(
 	jclass jclazz
 	)
 {
+	slf4j_setup_static(env, jclazz);
+
 #if defined(DEBUG) && defined(__linux__) && defined(UTS_RELEASE)
 	struct utsname name;
 	char message[80];
@@ -624,6 +627,8 @@ JNIEXPORT jint JNICALL RXTXPort(controlRs485)(
         jint delayRtsAfterSendMs
         )
 {
+	slf4j_setup_instance(env, jobj);
+
 #if defined(__linux__)
     struct serial_rs485 rs485conf;
     memset(&rs485conf, 0, sizeof(struct serial_rs485));
@@ -664,6 +669,8 @@ JNIEXPORT jint JNICALL RXTXPort(open)(
 	jstring jstr
 	)
 {
+	slf4j_setup_instance(env, jobj);
+
 	int fd;
 	int  pid = -1;
 	char message[80];
@@ -786,6 +793,8 @@ RXTXPort.nativeClose
 JNIEXPORT void JNICALL RXTXPort(nativeClose)( JNIEnv *env,
 	jobject jobj,jstring jstr )
 {
+	slf4j_setup_instance(env, jobj);
+
 	int result, pid;
 	int fd = get_java_var( env, jobj,"fd","I" );
 	const char *filename = (*env)->GetStringUTFChars( env, jstr, 0 );
@@ -977,6 +986,8 @@ JNIEXPORT jboolean JNICALL RXTXPort(nativeSetSerialPortParams)(
 	JNIEnv *env, jobject jobj, jint speed, jint dataBits, jint stopBits,
 	jint parity )
 {
+	slf4j_setup_instance(env, jobj);
+
 	int fd = get_java_var( env, jobj,"fd","I" );
 	int cspeed = translate_speed( env, speed );
 
@@ -1191,6 +1202,8 @@ int translate_stop_bits( JNIEnv *env, tcflag_t *cflag, jint stopBits )
 }
 JNIEXPORT jint JNICALL RXTXPort(nativeGetFlowControlMode)(JNIEnv *env, jobject jobj, jint fd)
 {
+	slf4j_setup_instance(env, jobj);
+
 	struct termios ttyset;
 	int ret = 0;
 
@@ -1212,6 +1225,8 @@ JNIEXPORT jint JNICALL RXTXPort(nativeGetFlowControlMode)(JNIEnv *env, jobject j
 }
 JNIEXPORT jint JNICALL RXTXPort(nativeGetParity)(JNIEnv *env, jobject jobj, jint fd)
 {
+	slf4j_setup_instance(env, jobj);
+
 	struct termios ttyset;
 
 	if( tcgetattr( fd, &ttyset ) < 0 )
@@ -1509,6 +1524,8 @@ RXTXPort.writeByte
 JNIEXPORT void JNICALL RXTXPort(writeByte)( JNIEnv *env,
 	jobject jobj, jint ji, jboolean interrupted )
 {
+	slf4j_setup_instance(env, jobj);
+
 #ifndef TIOCSERGETLSR
 	struct event_info_struct *index = master_index;
 #endif
@@ -1581,6 +1598,8 @@ JNIEXPORT void JNICALL RXTXPort(writeArray)( JNIEnv *env,
 	jobject jobj, jbyteArray jbarray, jint offset, jint count,
 		jboolean interrupted )
 {
+	slf4j_setup_instance(env, jobj);
+
 #ifndef TIOCSERGETLSR
 	struct event_info_struct *index = master_index;
 #endif /* TIOCSERGETLSR */
@@ -1681,6 +1700,8 @@ RXTXPort.nativeDrain
 JNIEXPORT jboolean JNICALL RXTXPort(nativeDrain)( JNIEnv *env,
 	jobject jobj, jboolean interrupted )
 {
+	slf4j_setup_instance(env, jobj);
+
 	int fd = get_java_var( env, jobj,"fd","I" );
 	struct event_info_struct *eis = ( struct event_info_struct * ) get_java_var_long( env, jobj, "eis", "J" );
 	int result, count=0;
@@ -1733,6 +1754,8 @@ RXTXPort.sendBreak
 JNIEXPORT void JNICALL RXTXPort(sendBreak)( JNIEnv *env,
 	jobject jobj, jint duration )
 {
+	slf4j_setup_instance(env, jobj);
+
 	int fd = get_java_var( env, jobj,"fd","I" );
 	report_time_start( );
 	ENTER( "RXTXPort:sendBreak()" );
@@ -1754,6 +1777,8 @@ JNIEXPORT jint JNICALL RXTXPort(NativegetReceiveTimeout)(
 	jobject jobj
 	)
 {
+	slf4j_setup_instance(env, jobj);
+
 	int fd = get_java_var( env, jobj,"fd","I" );
 	struct termios ttyset;
 
@@ -1781,6 +1806,8 @@ JNIEXPORT jboolean JNICALL RXTXPort(NativeisReceiveTimeoutEnabled)(
 	jobject jobj
 	)
 {
+	slf4j_setup_instance(env, jobj);
+
 	int fd = get_java_var( env, jobj,"fd","I" );
 	struct termios ttyset;
 	ENTER( "RXTXPort:NativeisRecieveTimeoutEnabled()" );
@@ -1807,6 +1834,8 @@ RXTXPort.isDSR
 JNIEXPORT jboolean JNICALL RXTXPort(isDSR)( JNIEnv *env,
 	jobject jobj )
 {
+	slf4j_setup_instance(env, jobj);
+
 	unsigned int result = 0;
 	int fd = get_java_var( env, jobj,"fd","I" );
 	char message[80];
@@ -1837,6 +1866,8 @@ RXTXPort.isCD
 JNIEXPORT jboolean JNICALL RXTXPort(isCD)( JNIEnv *env,
 	jobject jobj )
 {
+	slf4j_setup_instance(env, jobj);
+
 	unsigned int result = 0;
 	int fd = get_java_var( env, jobj,"fd","I" );
 	char message[80];
@@ -1862,6 +1893,8 @@ RXTXPort.isCTS
 JNIEXPORT jboolean JNICALL RXTXPort(isCTS)( JNIEnv *env,
 	jobject jobj )
 {
+	slf4j_setup_instance(env, jobj);
+
 	unsigned int result = 0;
 	int fd = get_java_var( env, jobj,"fd","I" );
 	char message[80];
@@ -1888,6 +1921,8 @@ RXTXPort.isRI
 JNIEXPORT jboolean JNICALL RXTXPort(isRI)( JNIEnv *env,
 	jobject jobj )
 {
+	slf4j_setup_instance(env, jobj);
+
 	unsigned int result = 0;
 	int fd = get_java_var( env, jobj,"fd","I" );
 	char message[80];
@@ -1914,6 +1949,8 @@ RXTXPort.isRTS
 JNIEXPORT jboolean JNICALL RXTXPort(isRTS)( JNIEnv *env,
 	jobject jobj )
 {
+	slf4j_setup_instance(env, jobj);
+
 	unsigned int result = 0;
 	int fd = get_java_var( env, jobj,"fd","I" );
 	char message[80];
@@ -1941,6 +1978,8 @@ RXTXPort.setRTS
 JNIEXPORT void JNICALL RXTXPort(setRTS)( JNIEnv *env,
 	jobject jobj, jboolean state )
 {
+	slf4j_setup_instance(env, jobj);
+
 	unsigned int result = 0;
 	int fd = get_java_var( env, jobj,"fd","I" );
 	char message[80];
@@ -1970,6 +2009,8 @@ RXTXPort.setDSR
 JNIEXPORT void JNICALL RXTXPort(setDSR)( JNIEnv *env,
 	jobject jobj, jboolean state )
 {
+	slf4j_setup_instance(env, jobj);
+
 	unsigned int result = 0;
 	int fd = get_java_var( env, jobj,"fd","I" );
 	char message[80];
@@ -2000,6 +2041,8 @@ RXTXPort.isDTR
 JNIEXPORT jboolean JNICALL RXTXPort(isDTR)( JNIEnv *env,
 	jobject jobj )
 {
+	slf4j_setup_instance(env, jobj);
+
 	unsigned int result = 0;
 	int fd = get_java_var( env, jobj,"fd","I" );
 	char message[80];
@@ -2026,6 +2069,8 @@ RXTXPort.setDTR
 JNIEXPORT void JNICALL RXTXPort(setDTR)( JNIEnv *env,
 	jobject jobj, jboolean state )
 {
+	slf4j_setup_instance(env, jobj);
+
 	unsigned int result = 0;
 	int fd = get_java_var( env, jobj,"fd","I" );
 	char message[80];
@@ -2113,6 +2158,7 @@ JNIEXPORT jboolean JNICALL RXTXPort(nativeSetBaudBase)(
 	jint BaudBase
 )
 {
+	slf4j_setup_instance(env, jobj);
 
 #if defined(TIOCGSERIAL)
 
@@ -2159,6 +2205,7 @@ JNIEXPORT jint JNICALL RXTXPort(nativeGetBaudBase)(
 	jobject jobj
 )
 {
+	slf4j_setup_instance(env, jobj);
 
 #if defined(TIOCGSERIAL)
 
@@ -2199,6 +2246,7 @@ JNIEXPORT jboolean JNICALL RXTXPort(nativeSetDivisor)(
 	jint Divisor
 )
 {
+	slf4j_setup_instance(env, jobj);
 
 #if defined(TIOCGSERIAL)
 
@@ -2243,6 +2291,7 @@ JNIEXPORT jint JNICALL RXTXPort(nativeGetDivisor)(
 	jobject jobj
 )
 {
+	slf4j_setup_instance(env, jobj);
 
 #if defined(TIOCGSERIAL)
 
@@ -2285,6 +2334,8 @@ RXTXPort.nativeStaticSetDSR
 JNIEXPORT jboolean JNICALL RXTXPort(nativeStaticSetDSR) (JNIEnv *env,
 	jclass jclazz, jstring jstr, jboolean flag)
 {
+	slf4j_setup_static(env, jclazz);
+
 	int fd;
 	int  pid = -1;
 	int result;
@@ -2351,6 +2402,8 @@ RXTXPort.nativeStaticSetRTS
 JNIEXPORT jboolean JNICALL RXTXPort(nativeStaticSetRTS) (JNIEnv *env,
 	jclass jclazz, jstring jstr, jboolean flag)
 {
+	slf4j_setup_static(env, jclazz);
+
 	int fd;
 	int  pid = -1;
 	int result;
@@ -2417,6 +2470,8 @@ RXTXPort.nativeStaticSetSerialPortParams
 JNIEXPORT void JNICALL RXTXPort(nativeStaticSetSerialPortParams) (JNIEnv *env,
 	jclass jclazz, jstring jstr, jint baudrate, jint dataBits, jint stopBits, jint parity )
 {
+	slf4j_setup_static(env, jclazz);
+
 	int fd;
 	int  pid = -1;
 	const char *filename = (*env)->GetStringUTFChars( env, jstr, 0 );
@@ -2501,6 +2556,8 @@ RXTXPort.nativeStaticSetDTR
 JNIEXPORT jboolean JNICALL RXTXPort(nativeStaticSetDTR) (JNIEnv *env,
 	jclass jclazz, jstring jstr, jboolean flag)
 {
+	slf4j_setup_static(env, jclazz);
+
 	int fd;
 	int  pid = -1;
 	const char *filename = (*env)->GetStringUTFChars( env, jstr, 0 );
@@ -2562,6 +2619,8 @@ RXTXPort.nativeStaticIsRTS
 JNIEXPORT jboolean JNICALL RXTXPort(nativeStaticIsRTS)( JNIEnv *env,
 	jobject jobj, jstring jstr )
 {
+	slf4j_setup_instance(env, jobj);
+
 	unsigned int result = 0;
 	const char *filename = (*env)->GetStringUTFChars( env, jstr, 0 );
 	int fd = find_preopened_ports( filename );
@@ -2594,6 +2653,8 @@ RXTXPort.nativeStaticIsDSR
 JNIEXPORT jboolean JNICALL RXTXPort(nativeStaticIsDSR)( JNIEnv *env,
 	jobject jobj, jstring jstr )
 {
+	slf4j_setup_instance(env, jobj);
+
 	unsigned int result = 0;
 	const char *filename = (*env)->GetStringUTFChars( env, jstr, 0 );
 	int fd = find_preopened_ports( filename );
@@ -2626,6 +2687,8 @@ RXTXPort.nativeStaticIsDTR
 JNIEXPORT jboolean JNICALL RXTXPort(nativeStaticIsDTR)( JNIEnv *env,
 	jobject jobj, jstring jstr )
 {
+	slf4j_setup_instance(env, jobj);
+
 	unsigned int result = 0;
 	const char *filename = (*env)->GetStringUTFChars( env, jstr, 0 );
 	int fd = find_preopened_ports( filename );
@@ -2658,6 +2721,8 @@ RXTXPort.nativeStaticIsCD
 JNIEXPORT jboolean JNICALL RXTXPort(nativeStaticIsCD)( JNIEnv *env,
 	jobject jobj, jstring jstr )
 {
+	slf4j_setup_instance(env, jobj);
+
 	unsigned int result = 0;
 	const char *filename = (*env)->GetStringUTFChars( env, jstr, 0 );
 	int fd = find_preopened_ports( filename );
@@ -2690,6 +2755,8 @@ RXTXPort.nativeStaticIsCTS
 JNIEXPORT jboolean JNICALL RXTXPort(nativeStaticIsCTS)( JNIEnv *env,
 	jobject jobj, jstring jstr )
 {
+	slf4j_setup_instance(env, jobj);
+
 	unsigned int result = 0;
 	const char *filename = (*env)->GetStringUTFChars( env, jstr, 0 );
 	int fd = find_preopened_ports( filename );
@@ -2722,6 +2789,8 @@ RXTXPort.nativeStaticIsRI
 JNIEXPORT jboolean JNICALL RXTXPort(nativeStaticIsRI)( JNIEnv *env,
 	jobject jobj, jstring jstr )
 {
+	slf4j_setup_instance(env, jobj);
+
 	unsigned int result = 0;
 	const char *filename = (*env)->GetStringUTFChars( env, jstr, 0 );
 	int fd = find_preopened_ports( filename );
@@ -2752,6 +2821,8 @@ RXTXPort.nativeStaticGetBaudRate
 ----------------------------------------------------------*/
 JNIEXPORT jint JNICALL RXTXPort(nativeStaticGetBaudRate)( JNIEnv *env, jobject jobj, jstring jstr )
 {
+	slf4j_setup_instance(env, jobj);
+
 	const char *filename = (*env)->GetStringUTFChars( env, jstr, 0 );
 	int fd = find_preopened_ports( filename );
 	struct termios ttyset;
@@ -2804,6 +2875,8 @@ RXTXPort.nativeStaticGetDataBits
 ----------------------------------------------------------*/
 JNIEXPORT jint JNICALL RXTXPort(nativeStaticGetDataBits)( JNIEnv *env, jobject jobj, jstring jstr )
 {
+	slf4j_setup_instance(env, jobj);
+
 	const char *filename = (*env)->GetStringUTFChars( env, jstr, 0 );
 	int fd = find_preopened_ports( filename );
 	struct termios ttyset;
@@ -2839,6 +2912,8 @@ RXTXPort.nativeStaticGetParity
 ----------------------------------------------------------*/
 JNIEXPORT jint JNICALL RXTXPort(nativeStaticGetParity)( JNIEnv *env, jobject jobj, jstring jstr )
 {
+	slf4j_setup_instance(env, jobj);
+
 	const char *filename = (*env)->GetStringUTFChars( env, jstr, 0 );
 	int fd = find_preopened_ports( filename );
 	struct termios ttyset;
@@ -2881,6 +2956,8 @@ RXTXPort.nativeStaticGetStopBits
 ----------------------------------------------------------*/
 JNIEXPORT jint JNICALL RXTXPort(nativeStaticGetStopBits)( JNIEnv *env, jobject jobj, jstring jstr )
 {
+	slf4j_setup_instance(env, jobj);
+
 	const char *filename = (*env)->GetStringUTFChars( env, jstr, 0 );
 	int fd = find_preopened_ports( filename );
 	struct termios ttyset;
@@ -2929,6 +3006,8 @@ RXTXPort.nativeGetParityErrorChar
 JNIEXPORT jbyte JNICALL RXTXPort(nativeGetParityErrorChar)( JNIEnv *env,
 	jobject jobj )
 {
+	slf4j_setup_instance(env, jobj);
+
 	unsigned int result = 0;
 
 	ENTER( "nativeGetParityErrorChar" );
@@ -2959,6 +3038,8 @@ RXTXPort.nativeGetEndOfInputChar
 JNIEXPORT jbyte JNICALL RXTXPort(nativeGetEndOfInputChar)( JNIEnv *env,
 	jobject jobj )
 {
+	slf4j_setup_instance(env, jobj);
+
 	int fd = get_java_var( env, jobj,"fd","I" );
 	struct termios ttyset;
 
@@ -2989,6 +3070,7 @@ RXTXPort.nativeSetParityErrorChar
 JNIEXPORT jboolean JNICALL RXTXPort(nativeSetParityErrorChar)( JNIEnv *env,
 	jobject jobj, jbyte value )
 	{
+	slf4j_setup_instance(env, jobj);
 
 #ifdef WIN32
 		int fd = get_java_var( env, jobj,"fd","I" );
@@ -3029,6 +3111,8 @@ RXTXPort.nativeSetEndOfInputChar
 JNIEXPORT jboolean JNICALL RXTXPort(nativeSetEndOfInputChar)( JNIEnv *env,
 	jobject jobj, jbyte value )
 {
+	slf4j_setup_instance(env, jobj);
+
 	int fd = get_java_var( env, jobj,"fd","I" );
 	struct termios ttyset;
 
@@ -3340,6 +3424,8 @@ NativeEnableReceiveTimeoutThreshold
 JNIEXPORT void JNICALL RXTXPort(NativeEnableReceiveTimeoutThreshold)(
 	JNIEnv *env, jobject jobj, jint vtime, jint threshold, jint buffer)
 {
+	slf4j_setup_instance(env, jobj);
+
 	int fd = get_java_var( env, jobj,"fd","I" );
 	struct termios ttyset;
 	int timeout;
@@ -3506,6 +3592,8 @@ until min(m,n) bytes are available
 JNIEXPORT jint JNICALL RXTXPort(readByte)( JNIEnv *env,
 	jobject jobj )
 {
+	slf4j_setup_instance(env, jobj);
+
 	int bytes;
 	unsigned char buffer[ 1 ];
 	int fd = get_java_var( env, jobj,"fd","I" );
@@ -3547,6 +3635,8 @@ RXTXPort.readArray
 JNIEXPORT jint JNICALL RXTXPort(readArray)( JNIEnv *env,
 	jobject jobj, jbyteArray jbarray, jint offset, jint length )
 {
+	slf4j_setup_instance(env, jobj);
+
 	int bytes;
 	jbyte *body;
 	/* char msg[80]; */
@@ -3599,6 +3689,8 @@ RXTXPort.nativeClearCommInput
 JNIEXPORT jboolean JNICALL RXTXPort(nativeClearCommInput)( JNIEnv *env,
 	jobject jobj )
 {
+	slf4j_setup_instance(env, jobj);
+
 	int fd = get_java_var( env, jobj, "fd", "I" );
 	if ( tcflush( fd, TCIFLUSH ) )
 		return( JNI_FALSE );
@@ -3624,6 +3716,8 @@ JNIEXPORT jint JNICALL RXTXPort(readTerminatedArray)( JNIEnv *env,
 	jobject jobj, jbyteArray jbarray, jint offset, jint length,
 	jbyteArray jterminator )
 {
+	slf4j_setup_instance(env, jobj);
+
 	int bytes, total = 0;
 	jbyte *body, *terminator;
 	/* char msg[80]; */
@@ -3689,6 +3783,8 @@ RXTXPort.nativeavailable
 JNIEXPORT jint JNICALL RXTXPort(nativeavailable)( JNIEnv *env,
 	jobject jobj )
 {
+	slf4j_setup_instance(env, jobj);
+
 	int fd = get_java_var( env, jobj,"fd","I" );
 	int result=-1;
 /*
@@ -3755,6 +3851,8 @@ RXTXPort.setflowcontrol
 JNIEXPORT void JNICALL RXTXPort(setflowcontrol)( JNIEnv *env,
 	jobject jobj, jint flowmode )
 {
+	slf4j_setup_instance(env, jobj);
+
 	struct termios ttyset;
 	int fd = get_java_var( env, jobj,"fd","I" );
 
@@ -4254,6 +4352,8 @@ RXTXPort.eventLoop
 ----------------------------------------------------------*/
 JNIEXPORT void JNICALL RXTXPort(eventLoop)( JNIEnv *env, jobject jobj )
 {
+	slf4j_setup_instance(env, jobj);
+
 #ifdef WIN32
 	int i = 0;
 #endif /* WIN32 */
@@ -4366,6 +4466,8 @@ JNIEXPORT jboolean  JNICALL RXTXCommDriver(testRead)(
 	jint port_type
 )
 {
+	slf4j_setup_instance(env, jobj);
+
 	char *name =(char *) (*env)->GetStringUTFChars(env, tty_name, 0);
 	int ret = JNI_TRUE;
 #ifndef WIN32
@@ -4746,6 +4848,8 @@ registerKnownSerialPorts(JNIEnv *env, jobject jobj, jint portType) /* dima */
 JNIEXPORT jboolean JNICALL RXTXCommDriver(registerKnownPorts)(JNIEnv *env,
     jobject jobj, jint portType)
 {
+	slf4j_setup_instance(env, jobj);
+
 	enum {PORT_TYPE_SERIAL = 1,
 		PORT_TYPE_PARALLEL,
 		PORT_TYPE_I2C,
@@ -4789,6 +4893,8 @@ JNIEXPORT jboolean JNICALL RXTXCommDriver(registerKnownPorts)(JNIEnv *env,
 JNIEXPORT jboolean  JNICALL RXTXCommDriver(isPortPrefixValid)(JNIEnv *env,
 	jobject jobj, jstring tty_name)
 {
+	slf4j_setup_instance(env, jobj);
+
 	jboolean result;
 	static struct stat mystat;
 	char teststring[256];
@@ -4860,6 +4966,8 @@ JNIEXPORT jboolean  JNICALL RXTXCommDriver(isPortPrefixValid)(JNIEnv *env,
 JNIEXPORT jstring  JNICALL RXTXCommDriver(getDeviceDirectory)(JNIEnv *env,
 	jobject jobj)
 {
+	slf4j_setup_instance(env, jobj);
+
 	ENTER( "RXTXCommDriver:getDeviceDirectory" );
 	return (*env)->NewStringUTF(env, DEVICEDIR);
 	LEAVE( "RXTXCommDriver:getDeviceDirectory" );
@@ -4877,6 +4985,7 @@ JNIEXPORT jstring  JNICALL RXTXCommDriver(getDeviceDirectory)(JNIEnv *env,
 JNIEXPORT void JNICALL RXTXPort(setInputBufferSize)(JNIEnv *env,
 	jobject jobj,  jint size )
 {
+	slf4j_setup_instance(env, jobj);
 	report( "setInputBufferSize is not implemented\n" );
 }
 
@@ -4892,6 +5001,7 @@ JNIEXPORT void JNICALL RXTXPort(setInputBufferSize)(JNIEnv *env,
 JNIEXPORT jint JNICALL RXTXPort(getInputBufferSize)(JNIEnv *env,
 	jobject jobj)
 {
+	slf4j_setup_instance(env, jobj);
 	report( "getInputBufferSize is not implemented\n" );
 	return(1);
 }
@@ -4908,6 +5018,7 @@ JNIEXPORT jint JNICALL RXTXPort(getInputBufferSize)(JNIEnv *env,
 JNIEXPORT void JNICALL RXTXPort(setOutputBufferSize)(JNIEnv *env,
 	jobject jobj, jint size )
 {
+	slf4j_setup_instance(env, jobj);
 	report( "setOutputBufferSize is not implemented\n" );
 }
 
@@ -4923,6 +5034,7 @@ JNIEXPORT void JNICALL RXTXPort(setOutputBufferSize)(JNIEnv *env,
 JNIEXPORT jint JNICALL RXTXPort(getOutputBufferSize)(JNIEnv *env,
 	jobject jobj)
 {
+	slf4j_setup_instance(env, jobj);
 	report( "getOutputBufferSize is not implemented\n" );
 	return(1);
 }
@@ -4942,6 +5054,8 @@ JNIEXPORT jint JNICALL RXTXPort(getOutputBufferSize)(JNIEnv *env,
 JNIEXPORT void JNICALL RXTXPort(interruptEventLoop)(JNIEnv *env,
 	jobject jobj)
 {
+	slf4j_setup_instance(env, jobj);
+
 	struct event_info_struct *index = master_index;
 	int fd = get_java_var( env, jobj, "fd", "I" );
 	int searching = 1;
@@ -5050,6 +5164,8 @@ JNIEXPORT void JNICALL RXTXPort(nativeSetEventFlag)( JNIEnv *env,
 							jint event,
 							jboolean flag )
 {
+	slf4j_setup_instance(env, jobj);
+
 	struct event_info_struct *index = master_index;
 
 	if( !index )
@@ -5194,65 +5310,6 @@ void throw_java_exception( JNIEnv *env, char *exc, char *foo, char *msg )
 /* ct7 * Added DeleteLocalRef */
 	(*env)->DeleteLocalRef( env, clazz );
 	LEAVE( "throw_java_exception" );
-}
-
-/*----------------------------------------------------------
- report_warning
-
-   accept:      string to send to report as an message
-   perform:     send the string to stderr or however it needs to be reported.
-   return:      none
-   exceptions:  none
-   comments:
-----------------------------------------------------------*/
-void report_warning(char *msg)
-{
-	fprintf(stderr, "%s", msg);
-}
-
-/*----------------------------------------------------------
- report_verbose
-
-   accept:      string to send to report as an verbose message
-   perform:     send the string to stderr or however it needs to be reported.
-   return:      none
-   exceptions:  none
-   comments:
-----------------------------------------------------------*/
-void report_verbose(char *msg)
-{
-#ifdef DEBUG_VERBOSE
-	fprintf(stderr, "%s", msg);
-#endif /* DEBUG_VERBOSE */
-}
-/*----------------------------------------------------------
- report_error
-
-   accept:      string to send to report as an error
-   perform:     send the string to stderr or however it needs to be reported.
-   return:      none
-   exceptions:  none
-   comments:
-----------------------------------------------------------*/
-void report_error(char *msg)
-{
-	fprintf(stderr, "%s", msg);
-}
-
-/*----------------------------------------------------------
- report
-
-   accept:      string to send to stderr
-   perform:     if DEBUG is defined send the string to stderr.
-   return:      none
-   exceptions:  none
-   comments:
-----------------------------------------------------------*/
-void report(char *msg)
-{
-#ifdef DEBUG
-	fprintf(stderr, "%s", msg);
-#endif /* DEBUG */
 }
 
 #ifndef WIN32
@@ -6229,7 +6286,6 @@ JNI_OnLoad
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *java_vm, void *reserved)
 {
 	javaVM = java_vm;
-	report_verbose("JNI_OnLoad called.\n");
 	return JNI_VERSION_1_2;  /* JNI API used */
 }
 
@@ -6247,7 +6303,6 @@ JNI_OnUnload
 JNIEXPORT void JNICALL JNI_OnUnload(JavaVM *vm, void *reserved)
 {
 	/* never called it appears */
-	printf("Experimental:  JNI_OnUnload called.\n");
 }
 
 #ifdef asdf

--- a/src/main/c/src/slf4j.c
+++ b/src/main/c/src/slf4j.c
@@ -171,7 +171,7 @@ Slf4jContext *slf4j__setup_static(JNIEnv *env, jclass jclazz)
 	return thread_context;
 }
 
-void slf4j_teardown(Slf4jContext **context)
+void slf4j_teardown(Slf4jContext **unused)
 {
 	if (thread_context == NULL)
 	{

--- a/src/main/c/src/slf4j.c
+++ b/src/main/c/src/slf4j.c
@@ -1,0 +1,154 @@
+/*-------------------------------------------------------------------------
+|   RXTX License v 2.1 - LGPL v 2.1 + Linking Over Controlled Interface.
+|   RXTX is a native interface to serial ports in java.
+|   Copyright 1997-2009 by Trent Jarvi tjarvi@qbang.org and others who
+|   actually wrote it.  See individual source files for more information.
+|
+|   A copy of the LGPL v 2.1 may be found at
+|   http://www.gnu.org/licenses/lgpl.txt on March 4th 2007.  A copy is
+|   here for your convenience.
+|
+|   This library is free software; you can redistribute it and/or
+|   modify it under the terms of the GNU Lesser General Public
+|   License as published by the Free Software Foundation; either
+|   version 2.1 of the License, or (at your option) any later version.
+|
+|   This library is distributed in the hope that it will be useful,
+|   but WITHOUT ANY WARRANTY; without even the implied warranty of
+|   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+|   Lesser General Public License for more details.
+|
+|   An executable that contains no derivative of any portion of RXTX, but
+|   is designed to work with RXTX by being dynamically linked with it,
+|   is considered a "work that uses the Library" subject to the terms and
+|   conditions of the GNU Lesser General Public License.
+|
+|   The following has been added to the RXTX License to remove
+|   any confusion about linking to RXTX.   We want to allow in part what
+|   section 5, paragraph 2 of the LGPL does not permit in the special
+|   case of linking over a controlled interface.  The intent is to add a
+|   Java Specification Request or standards body defined interface in the
+|   future as another exception but one is not currently available.
+|
+|   http://www.fsf.org/licenses/gpl-faq.html#LinkingOverControlledInterface
+|
+|   As a special exception, the copyright holders of RXTX give you
+|   permission to link RXTX with independent modules that communicate with
+|   RXTX solely through the Sun Microsytems CommAPI interface version 2,
+|   regardless of the license terms of these independent modules, and to copy
+|   and distribute the resulting combined work under terms of your choice,
+|   provided that every copy of the combined work is accompanied by a complete
+|   copy of the source code of RXTX (the version of RXTX used to produce the
+|   combined work), being distributed under the terms of the GNU Lesser General
+|   Public License plus this exception.  An independent module is a
+|   module which is not derived from or based on RXTX.
+|
+|   Note that people who make modified versions of RXTX are not obligated
+|   to grant this special exception for their modified versions; it is
+|   their choice whether to do so.  The GNU Lesser General Public License
+|   gives permission to release a modified version without this exception; this
+|   exception also makes it possible to release a modified version which
+|   carries forward this exception.
+|
+|   You should have received a copy of the GNU Lesser General Public
+|   License along with this library; if not, write to the Free
+|   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+|   All trademarks belong to their respective owners.
+--------------------------------------------------------------------------*/
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+#include "slf4j.h"
+
+/** \brief The maximum length of a log message. */
+#define MESSAGE_MAX 4096
+
+typedef struct Slf4jContext
+{
+	JNIEnv *env;
+	jobject log;
+} Slf4jContext;
+
+static __thread Slf4jContext context = {0};
+
+void slf4j_log(LogLevel level, const char *msg)
+{
+	if (context.env == NULL)
+	{
+		/* No context? No logging. */
+		return;
+	}
+
+	const char *methodName;
+	switch (level)
+	{
+	case LOG_ERROR:
+		methodName = "error";
+		break;
+	case LOG_WARN:
+		methodName = "warn";
+		break;
+	case LOG_INFO:
+		methodName = "info";
+		break;
+	case LOG_DEBUG:
+		methodName = "debug";
+		break;
+	case LOG_TRACE:
+	default:
+		methodName = "trace";
+		break;
+	}
+
+	/* The report() functions used to just conditionally printf whatever was
+	 * handed to them, so all of those invocations pass strings with trailing
+	 * newlines. We'll trim any trailing whitespace before passing to SLF4J. */
+	int messageLength = strlen(msg);
+	while (isspace(msg[messageLength - 1]))
+	{
+		--messageLength;
+	}
+
+	/* A log message 4K in length is likely already an error. Anything longer
+	 * is _definitely_ an error. */
+	if (messageLength > MESSAGE_MAX)
+	{
+		messageLength = MESSAGE_MAX;
+	}
+
+	char *trimmedMessage = strndup(msg, messageLength);
+	jstring jmsg = (*context.env)->NewStringUTF(
+		context.env,
+		trimmedMessage);
+	free(trimmedMessage);
+
+	jclass logger = (*context.env)->FindClass(context.env, "org/slf4j/Logger");
+	jmethodID logMethod = (*context.env)->GetMethodID(
+		context.env,
+		logger,
+		methodName,
+		"(Ljava/lang/String;)V");
+
+	(*context.env)->CallVoidMethod(context.env, context.log, logMethod, jmsg);
+}
+
+void slf4j_setup_instance(JNIEnv *env, jobject jobj)
+{
+	jclass jclazz = (*env)->GetObjectClass(env, jobj);
+	slf4j_setup_static(env, jclazz);
+}
+
+void slf4j_setup_static(JNIEnv *env, jclass jclazz)
+{
+	jfieldID logId = (*env)->GetStaticFieldID(env, jclazz, "log", "Lorg/slf4j/Logger;");
+	jobject log = (*env)->GetStaticObjectField(env, jclazz, logId);
+
+	context.env = env;
+	context.log = log;
+}
+
+void slf4j_teardown()
+{
+	memset(&context, 0, sizeof(Slf4jContext));
+}

--- a/src/main/c/src/slf4j.c
+++ b/src/main/c/src/slf4j.c
@@ -123,7 +123,10 @@ void slf4j_log(LogLevel level, const char *msg)
 		messageLength = MESSAGE_MAX;
 	}
 
-	char *trimmedMessage = strndup(msg, messageLength);
+	char *trimmedMessage = malloc(messageLength + 1);
+	memcpy(trimmedMessage, msg, messageLength);
+	trimmedMessage[messageLength] = '\0';
+
 	jstring jmsg = (*thread_context->env)->NewStringUTF(
 		thread_context->env,
 		trimmedMessage);

--- a/src/main/c/src/windows/termios.c
+++ b/src/main/c/src/windows/termios.c
@@ -1,10 +1,3 @@
-#ifdef TRENT_IS_HERE
-#define TRACE
-#define DEBUG
-#endif /* TRENT_IS_HERE */
-extern void report( char * );
-extern void report_warning( char * );
-extern void report_error( char * );
 /*-------------------------------------------------------------------------
 |   RXTX License v 2.1 - LGPL v 2.1 + Linking Over Controlled Interface.
 |   RXTX is a native interface to serial ports in java.
@@ -68,6 +61,7 @@ extern void report_error( char * );
 #include <errno.h>
 #include <time.h>
 #include "win32termios.h"
+#include "slf4j.h"
 
 /*
  * odd malloc.h error with lcc compiler

--- a/src/main/java/gnu/io/CommPort.java
+++ b/src/main/java/gnu/io/CommPort.java
@@ -61,6 +61,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
 * @author Trent Jarvi
 * @version %I%, %G%
@@ -72,8 +75,9 @@ import java.io.IOException;
   * CommPort
   */
 public abstract class CommPort extends Object {
+	private static final Logger log = LoggerFactory.getLogger(CommPort.class);
+
 	protected String name;
-	private final static boolean debug = false;
 
 	public abstract void enableReceiveFraming( int f ) 
 		throws UnsupportedCommOperationException;
@@ -97,7 +101,7 @@ public abstract class CommPort extends Object {
 	@SuppressWarnings("static-access")
 	public void close() 
 	{
-		if (debug) System.out.println("CommPort:close()");
+		log.trace("CommPort:close()");
 
 		try
 		{
@@ -116,12 +120,12 @@ public abstract class CommPort extends Object {
 
 	public String getName()
 	{
-		if (debug) System.out.println("CommPort:getName()");
+		log.trace("CommPort:getName()");
 		return( name );
 	}
 	public String toString()
 	{
-		if (debug) System.out.println("CommPort:toString()");
+		log.trace("CommPort:toString()");
 		return( name );
 	}
 }

--- a/src/main/java/gnu/io/CommPort.java
+++ b/src/main/java/gnu/io/CommPort.java
@@ -120,12 +120,10 @@ public abstract class CommPort extends Object {
 
 	public String getName()
 	{
-		log.trace("CommPort:getName()");
 		return( name );
 	}
 	public String toString()
 	{
-		log.trace("CommPort:toString()");
 		return( name );
 	}
 }

--- a/src/main/java/gnu/io/CommPortEnumerator.java
+++ b/src/main/java/gnu/io/CommPortEnumerator.java
@@ -59,9 +59,6 @@ package  gnu.io;
 
 import java.util.Enumeration;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
 * @author Trent Jarvi
 * @version %I%, %G%
@@ -72,13 +69,7 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("unchecked")
 class CommPortEnumerator implements Enumeration
 {
-	private static final Logger log = LoggerFactory.getLogger(CommPortEnumerator.class);
-
 	private CommPortIdentifier index;
-	static
-	{
-		log.trace("CommPortEnumerator:{}");
-	}
 
 	CommPortEnumerator()
 	{
@@ -93,7 +84,6 @@ class CommPortEnumerator implements Enumeration
 ------------------------------------------------------------------------------*/
 	public Object nextElement()
 	{
-		log.trace("CommPortEnumerator:nextElement()");
 		synchronized (CommPortIdentifier.Sync)
 		{
 			if(index != null) index = index.next;
@@ -111,7 +101,6 @@ class CommPortEnumerator implements Enumeration
 ------------------------------------------------------------------------------*/
 	public boolean hasMoreElements()
 	{
-		log.trace("CommPortEnumerator:hasMoreElements() " + String.valueOf(CommPortIdentifier.CommPortIndex != null));
 		synchronized (CommPortIdentifier.Sync)
 		{
 			if(index != null) return index.next == null ? false : true;

--- a/src/main/java/gnu/io/CommPortEnumerator.java
+++ b/src/main/java/gnu/io/CommPortEnumerator.java
@@ -59,6 +59,9 @@ package  gnu.io;
 
 import java.util.Enumeration;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
 * @author Trent Jarvi
 * @version %I%, %G%
@@ -69,12 +72,12 @@ import java.util.Enumeration;
 @SuppressWarnings("unchecked")
 class CommPortEnumerator implements Enumeration
 {
+	private static final Logger log = LoggerFactory.getLogger(CommPortEnumerator.class);
+
 	private CommPortIdentifier index;
-	private final static boolean debug = false;
 	static
 	{
-		if (debug)
-			System.out.println("CommPortEnumerator:{}");
+		log.trace("CommPortEnumerator:{}");
 	}
 
 	CommPortEnumerator()
@@ -90,7 +93,7 @@ class CommPortEnumerator implements Enumeration
 ------------------------------------------------------------------------------*/
 	public Object nextElement()
 	{
-		if(debug) System.out.println("CommPortEnumerator:nextElement()");
+		log.trace("CommPortEnumerator:nextElement()");
 		synchronized (CommPortIdentifier.Sync)
 		{
 			if(index != null) index = index.next;
@@ -108,7 +111,7 @@ class CommPortEnumerator implements Enumeration
 ------------------------------------------------------------------------------*/
 	public boolean hasMoreElements()
 	{
-		if(debug) System.out.println("CommPortEnumerator:hasMoreElements() " + CommPortIdentifier.CommPortIndex == null ? false : true );
+		log.trace("CommPortEnumerator:hasMoreElements() " + String.valueOf(CommPortIdentifier.CommPortIndex != null));
 		synchronized (CommPortIdentifier.Sync)
 		{
 			if(index != null) return index.next == null ? false : true;

--- a/src/main/java/gnu/io/CommPortIdentifier.java
+++ b/src/main/java/gnu/io/CommPortIdentifier.java
@@ -106,7 +106,6 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 	// initialization only done once....
 	static 
 	{
-		log.trace("CommPortIdentifier:static initialization()");
 		Sync = new Object();
 		try 
 		{
@@ -115,7 +114,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 		} 
 		catch (Throwable e) 
 		{
-			log.error("Exception thrown while loading gnu.io.RXTXCommDriver", e);
+			log.error("Failed to load gnu.io.RXTXCommDriver: {}", e.getMessage());
 		}
 
 		String OS;
@@ -163,7 +162,6 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 ------------------------------------------------------------------------------*/
 	private static void AddIdentifierToList( CommPortIdentifier cpi)
 	{
-		log.trace("CommPortIdentifier:AddIdentifierToList()");
 		synchronized (Sync) 
 		{
 			if (CommPortIndex == null) 
@@ -177,7 +175,6 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 				while (index.next != null)
 				{
 					index = index.next;
-					log.trace("CommPortIdentifier:AddIdentifierToList() index.next");
 				}
 				index.next = cpi;
 			} 
@@ -194,8 +191,6 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 	@SuppressWarnings("unchecked")
 	public void addPortOwnershipListener(CommPortOwnershipListener c) 
 	{ 
-		log.trace("CommPortIdentifier:addPortOwnershipListener()");
-
 		/*  is the Vector instantiated? */
 
 		if( ownershipListener == null )
@@ -220,7 +215,6 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 ------------------------------------------------------------------------------*/
 	public String getCurrentOwner() 
 	{ 
-		log.trace("CommPortIdentifier:getCurrentOwner()");
 		return( Owner );
 	}
 /*------------------------------------------------------------------------------
@@ -233,7 +227,6 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 ------------------------------------------------------------------------------*/
 	public String getName() 
 	{ 
-		log.trace("CommPortIdentifier:getName()");
 		return( PortName );
 	}
 /*------------------------------------------------------------------------------
@@ -247,7 +240,6 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 	static public CommPortIdentifier getPortIdentifier(String s) throws NoSuchPortException 
 	{ 
 		CommPortIdentifier.getPortIdentifiers();
-		log.trace("CommPortIdentifier:getPortIdentifier(" + s +")");
 		CommPortIdentifier index;
 
 		synchronized (Sync) 
@@ -272,7 +264,6 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 		if (index != null) return index;
 		else
 		{
-			log.debug("not found!" + s);
 			throw new NoSuchPortException();
 		}
 	}
@@ -288,7 +279,6 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 		throws NoSuchPortException 	
 	{ 
 		CommPortIdentifier.getPortIdentifiers();
-		log.trace("CommPortIdentifier:getPortIdentifier(CommPort)");
 		CommPortIdentifier c;
 		synchronized( Sync )
 		{
@@ -299,7 +289,6 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 		if ( c != null )
 			return (c);
 
-		log.debug("not found!" + p.getName());
 		throw new NoSuchPortException();
 	}
 /*------------------------------------------------------------------------------
@@ -313,7 +302,6 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 	@SuppressWarnings("unchecked")
 	static public Enumeration getPortIdentifiers() 
 	{ 
-		log.trace("static CommPortIdentifier:getPortIdentifiers()");
 		//Do not allow anybody get any ports while we are re-initializing
 		//because the CommPortIndex points to invalid instances during that time
 		synchronized(Sync) {
@@ -374,7 +362,6 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 ------------------------------------------------------------------------------*/
 	public int getPortType() 
 	{ 
-		log.trace("CommPortIdentifier:getPortType()");
 		return( PortType );
 	}
 /*------------------------------------------------------------------------------
@@ -387,7 +374,6 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 ------------------------------------------------------------------------------*/
 	public synchronized boolean isCurrentlyOwned() 
 	{ 
-		log.trace("CommPortIdentifier:isCurrentlyOwned()");
 		return(!Available);
 	}
 /*------------------------------------------------------------------------------
@@ -400,7 +386,6 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 ------------------------------------------------------------------------------*/
 	public synchronized CommPort open(FileDescriptor f) throws UnsupportedCommOperationException 
 	{ 
-		log.trace("CommPortIdentifier:open(FileDescriptor)");
 		throw new UnsupportedCommOperationException();
 	}
 	private native String native_psmisc_report_owner(String PortName);
@@ -421,6 +406,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 		throws gnu.io.PortInUseException 
 	{ 
 		log.trace("CommPortIdentifier:open("+TheOwner + ", " +i+")");
+
 		boolean isAvailable;
 		synchronized(this) {
 			isAvailable = this.Available;
@@ -469,6 +455,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 			if(commport != null)
 			{
 				fireOwnershipEvent(CommPortOwnershipListener.PORT_OWNED);
+				log.debug("Opened {} ({}) by {}", PortName, commport, Owner);
 				return commport;
 			}
 			else
@@ -495,7 +482,6 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 ------------------------------------------------------------------------------*/
 	public void removePortOwnershipListener(CommPortOwnershipListener c) 
 	{ 
-		log.trace("CommPortIdentifier:removePortOwnershipListener()");
 		/* why is this called twice? */
 		if(ownershipListener != null)
 			ownershipListener.removeElement(c);
@@ -512,7 +498,6 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 	void internalClosePort() 
 	{
 		synchronized(this) {
-			log.trace("CommPortIdentifier:internalClosePort()");
 			Owner = null;
 			Available = true;
 			commport = null;

--- a/src/main/java/gnu/io/CommPortIdentifier.java
+++ b/src/main/java/gnu/io/CommPortIdentifier.java
@@ -63,6 +63,9 @@ import java.util.HashMap;
 import  java.util.Vector;
 import  java.util.Enumeration;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
 * @author Trent Jarvi
 * @version %I%, %G%
@@ -71,6 +74,8 @@ import  java.util.Enumeration;
 
 public class CommPortIdentifier extends Object /* extends Vector? */
 {
+	private static final Logger log = LoggerFactory.getLogger(CommPortIdentifier.class);
+
 	public static final int PORT_SERIAL   = 1;  // rs232 Port
 	public static final int PORT_PARALLEL = 2;  // Parallel Port
 	public static final int PORT_I2C      = 3;  // i2c Port
@@ -84,7 +89,6 @@ public class CommPortIdentifier extends Object /* extends Vector? */
  	static CommPortIdentifier   CommPortIndex;
 	CommPortIdentifier next;
 	private int PortType;
-	private final static boolean debug = false;
 	static Object Sync;
 	@SuppressWarnings("unchecked")
 	Vector ownershipListener;
@@ -102,7 +106,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 	// initialization only done once....
 	static 
 	{
-		if(debug) System.out.println("CommPortIdentifier:static initialization()");
+		log.trace("CommPortIdentifier:static initialization()");
 		Sync = new Object();
 		try 
 		{
@@ -111,7 +115,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 		} 
 		catch (Throwable e) 
 		{
-			System.err.println(e + " thrown while loading " + "gnu.io.RXTXCommDriver");
+			log.error("Exception thrown while loading gnu.io.RXTXCommDriver", e);
 		}
 
 		String OS;
@@ -119,8 +123,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 		OS = System.getProperty("os.name");
 		if(OS.toLowerCase().indexOf("linux") == -1)
 		{
-			if (debug)
-				System.out.println("Have not implemented native_psmisc_report_owner(PortName)); in CommPortIdentifier");
+			log.debug("Have not implemented native_psmisc_report_owner(PortName)); in CommPortIdentifier");
 		}
 		//System.loadLibrary( "rxtxSerial" );
 		SerialManager.getInstance();
@@ -147,7 +150,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 	public static void addPortName(String s, int type, CommDriver c) 
 	{ 
 
-		if(debug) System.out.println("CommPortIdentifier:addPortName("+s+")");
+		log.trace("CommPortIdentifier:addPortName("+s+")");
 		AddIdentifierToList(new CommPortIdentifier(s, null, type, c));
 	}
 /*------------------------------------------------------------------------------
@@ -160,13 +163,13 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 ------------------------------------------------------------------------------*/
 	private static void AddIdentifierToList( CommPortIdentifier cpi)
 	{
-		if(debug) System.out.println("CommPortIdentifier:AddIdentifierToList()");
+		log.trace("CommPortIdentifier:AddIdentifierToList()");
 		synchronized (Sync) 
 		{
 			if (CommPortIndex == null) 
 			{
 				CommPortIndex = cpi;
-				if(debug) System.out.println("CommPortIdentifier:AddIdentifierToList() null");
+				log.trace("CommPortIdentifier:AddIdentifierToList() null");
 			}
 			else
 			{ 
@@ -174,7 +177,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 				while (index.next != null)
 				{
 					index = index.next;
-					if(debug) System.out.println("CommPortIdentifier:AddIdentifierToList() index.next");
+					log.trace("CommPortIdentifier:AddIdentifierToList() index.next");
 				}
 				index.next = cpi;
 			} 
@@ -191,7 +194,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 	@SuppressWarnings("unchecked")
 	public void addPortOwnershipListener(CommPortOwnershipListener c) 
 	{ 
-		if(debug) System.out.println("CommPortIdentifier:addPortOwnershipListener()");
+		log.trace("CommPortIdentifier:addPortOwnershipListener()");
 
 		/*  is the Vector instantiated? */
 
@@ -217,7 +220,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 ------------------------------------------------------------------------------*/
 	public String getCurrentOwner() 
 	{ 
-		if(debug) System.out.println("CommPortIdentifier:getCurrentOwner()");
+		log.trace("CommPortIdentifier:getCurrentOwner()");
 		return( Owner );
 	}
 /*------------------------------------------------------------------------------
@@ -230,7 +233,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 ------------------------------------------------------------------------------*/
 	public String getName() 
 	{ 
-		if(debug) System.out.println("CommPortIdentifier:getName()");
+		log.trace("CommPortIdentifier:getName()");
 		return( PortName );
 	}
 /*------------------------------------------------------------------------------
@@ -244,7 +247,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 	static public CommPortIdentifier getPortIdentifier(String s) throws NoSuchPortException 
 	{ 
 		CommPortIdentifier.getPortIdentifiers();
-		if(debug) System.out.println("CommPortIdentifier:getPortIdentifier(" + s +")");
+		log.trace("CommPortIdentifier:getPortIdentifier(" + s +")");
 		CommPortIdentifier index;
 
 		synchronized (Sync) 
@@ -269,8 +272,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 		if (index != null) return index;
 		else
 		{
-			if ( debug )
-				System.out.println("not found!" + s);
+			log.debug("not found!" + s);
 			throw new NoSuchPortException();
 		}
 	}
@@ -286,7 +288,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 		throws NoSuchPortException 	
 	{ 
 		CommPortIdentifier.getPortIdentifiers();
-		if(debug) System.out.println("CommPortIdentifier:getPortIdentifier(CommPort)");
+		log.trace("CommPortIdentifier:getPortIdentifier(CommPort)");
 		CommPortIdentifier c;
 		synchronized( Sync )
 		{
@@ -297,8 +299,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 		if ( c != null )
 			return (c);
 
-		if ( debug )
-			System.out.println("not found!" + p.getName());
+		log.debug("not found!" + p.getName());
 		throw new NoSuchPortException();
 	}
 /*------------------------------------------------------------------------------
@@ -312,7 +313,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 	@SuppressWarnings("unchecked")
 	static public Enumeration getPortIdentifiers() 
 	{ 
-		if(debug) System.out.println("static CommPortIdentifier:getPortIdentifiers()");
+		log.trace("static CommPortIdentifier:getPortIdentifiers()");
 		//Do not allow anybody get any ports while we are re-initializing
 		//because the CommPortIndex points to invalid instances during that time
 		synchronized(Sync) {
@@ -357,8 +358,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 			} 
 			catch (Throwable e) 
 			{
-				System.err.println(e + " thrown while loading " + "gnu.io.RXTXCommDriver");
-				System.err.flush();
+				log.error("Exception thrown while loading gnu.io.RXTXCommDriver", e);
 			}
 		}
 		return new CommPortEnumerator();
@@ -374,7 +374,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 ------------------------------------------------------------------------------*/
 	public int getPortType() 
 	{ 
-		if(debug) System.out.println("CommPortIdentifier:getPortType()");
+		log.trace("CommPortIdentifier:getPortType()");
 		return( PortType );
 	}
 /*------------------------------------------------------------------------------
@@ -387,7 +387,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 ------------------------------------------------------------------------------*/
 	public synchronized boolean isCurrentlyOwned() 
 	{ 
-		if(debug) System.out.println("CommPortIdentifier:isCurrentlyOwned()");
+		log.trace("CommPortIdentifier:isCurrentlyOwned()");
 		return(!Available);
 	}
 /*------------------------------------------------------------------------------
@@ -400,7 +400,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 ------------------------------------------------------------------------------*/
 	public synchronized CommPort open(FileDescriptor f) throws UnsupportedCommOperationException 
 	{ 
-		if(debug) System.out.println("CommPortIdentifier:open(FileDescriptor)");
+		log.trace("CommPortIdentifier:open(FileDescriptor)");
 		throw new UnsupportedCommOperationException();
 	}
 	private native String native_psmisc_report_owner(String PortName);
@@ -420,7 +420,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 	public RXTXPort open(String TheOwner, int i) 
 		throws gnu.io.PortInUseException 
 	{ 
-		if(debug) System.out.println("CommPortIdentifier:open("+TheOwner + ", " +i+")");
+		log.trace("CommPortIdentifier:open("+TheOwner + ", " +i+")");
 		boolean isAvailable;
 		synchronized(this) {
 			isAvailable = this.Available;
@@ -495,7 +495,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 ------------------------------------------------------------------------------*/
 	public void removePortOwnershipListener(CommPortOwnershipListener c) 
 	{ 
-		if(debug) System.out.println("CommPortIdentifier:removePortOwnershipListener()");
+		log.trace("CommPortIdentifier:removePortOwnershipListener()");
 		/* why is this called twice? */
 		if(ownershipListener != null)
 			ownershipListener.removeElement(c);
@@ -512,7 +512,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 	void internalClosePort() 
 	{
 		synchronized(this) {
-			if(debug) System.out.println("CommPortIdentifier:internalClosePort()");
+			log.trace("CommPortIdentifier:internalClosePort()");
 			Owner = null;
 			Available = true;
 			commport = null;
@@ -532,7 +532,7 @@ public class CommPortIdentifier extends Object /* extends Vector? */
 	@SuppressWarnings("unchecked")
 	void fireOwnershipEvent(int eventType)
 	{
-		if(debug) System.out.println("CommPortIdentifier:fireOwnershipEvent( " + eventType + " )");
+		log.trace("CommPortIdentifier:fireOwnershipEvent( " + eventType + " )");
 		if (ownershipListener != null)
 		{
 			CommPortOwnershipListener c;

--- a/src/main/java/gnu/io/NRSerialPort.java
+++ b/src/main/java/gnu/io/NRSerialPort.java
@@ -69,8 +69,12 @@ import gnu.io.factory.RFC2217PortCreator;
 import gnu.io.factory.RxTxPortCreator;
 import gnu.io.rfc2217.TelnetSerialPort;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class NRSerialPort
 {
+    private static final Logger log = LoggerFactory.getLogger(NRSerialPort.class);
 
     private SerialPort serial;
     private String port = null;
@@ -125,7 +129,7 @@ public class NRSerialPort
     {
         if (isConnected())
         {
-            System.err.println(port + " is already connected.");
+            log.error(port + " is already connected.");
             return true;
         }
 
@@ -144,8 +148,7 @@ public class NRSerialPort
         }
         catch (Exception e)
         {
-            System.err.println("Failed to connect on port: " + port + " exception: ");
-            e.printStackTrace();
+            log.error("Failed to connect on port: " + port, e);
             setConnected(false);
         }
 

--- a/src/main/java/gnu/io/NRSerialPort.java
+++ b/src/main/java/gnu/io/NRSerialPort.java
@@ -129,7 +129,7 @@ public class NRSerialPort
     {
         if (isConnected())
         {
-            log.error(port + " is already connected.");
+            log.warn(port + " is already connected.");
             return true;
         }
 

--- a/src/main/java/gnu/io/NativeResource.java
+++ b/src/main/java/gnu/io/NativeResource.java
@@ -62,7 +62,11 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class NativeResource {
+	private static final Logger log = LoggerFactory.getLogger(NativeResource.class);
 
 	private boolean loaded = false;
 	public synchronized void load(String libraryName) throws NativeResourceException {
@@ -105,14 +109,14 @@ public class NativeResource {
 	private void loadLib(String name) throws NativeResourceException {
 		try {
 			if(OSUtil.isARM()) {
-				//System.err.println("Attempting arm variants");
+				log.debug("Attempting arm variants");
 				for(String libName : OSUtil.is64Bit() ? ARM64_LIBS : ARM32_LIBS) {
 					try {
 						inJarLoad(libName);
-						//System.err.println("Arm lib success! "+libName);
+						log.debug("Arm lib success! "+libName);
 						return;
 					}catch(UnsatisfiedLinkError e) {
-						//System.err.println("Is not "+libName);
+						log.debug("Is not "+libName);
 					}
 				}
 			}else {
@@ -123,7 +127,7 @@ public class NativeResource {
 			if(OSUtil.isOSX() || OSUtil.isLinux()){
 				try{
 					inJarLoad("libNRJavaSerial_legacy");
-					//System.err.println("Normal lib failed, using legacy..OK!");
+					log.debug("Normal lib failed, using legacy..OK!");
 					return;
 				}catch(UnsatisfiedLinkError er){
 					ex.printStackTrace();
@@ -145,7 +149,7 @@ public class NativeResource {
 					testNativeCode();
 					return;
 				}catch(UnsatisfiedLinkError err){
-					//System.err.println("Failed to load all possible JNI local and from: \n"+System.getProperty("java.library.path"));
+					log.error("Failed to load all possible JNI local and from: \n"+System.getProperty("java.library.path"));
 					ex.printStackTrace();
 					throw new NativeResourceException("Unable to load deployed native resource");
 				}
@@ -192,10 +196,10 @@ public class NativeResource {
 				file="/native/freebsd/x86_32/" + name;
 			}
 		}else{
-			//System.err.println("Can't load native file: "+name+" for os arch: "+OSUtil.getOsArch());
+			log.debug("Can't load native file: "+name+" for os arch: "+OSUtil.getOsArch());
 			return null;
 		}
-		//System.out.println("Loading "+file);
+		log.debug("Loading "+file);
 		return getClass().getResourceAsStream(file);
 	}
 
@@ -203,11 +207,11 @@ public class NativeResource {
 		if(!resource.canRead()) {
 			throw new RuntimeException("Cant open JNI file: "+resource.getAbsolutePath());
 		}
-		//System.out.println("Loading: "+resource.getAbsolutePath());
+		log.debug("Loading: "+resource.getAbsolutePath());
 		try {
 			System.load(resource.getAbsolutePath());
 		} catch(UnsatisfiedLinkError e){
-			System.out.println(e.getMessage());
+			log.error("Error loading resource", e);
 			throw e;
 		}
 	}
@@ -289,13 +293,13 @@ public class NativeResource {
 		if(fd == null || !fd.canRead()) {
 			throw new NativeResourceException("Unable to deploy native resource");
 		}
-		//System.out.println("Local file: "+fd.getAbsolutePath());
+		log.debug("Local file: "+fd.getAbsolutePath());
 		return fd;
 	}
 
 	private static class OSUtil {
 		public static boolean is64Bit() {
-			////System.out.println("Arch: "+getOsArch());
+			log.debug("Arch: "+getOsArch());
 			return getOsArch().startsWith("x86_64") || getOsArch().startsWith("amd64")  || getOsArch().startsWith("aarch64");
 		}
 		public static boolean isARM() {
@@ -305,7 +309,7 @@ public class NativeResource {
 			return getOsArch().toLowerCase().contains("ppc");
 		}
 		public static boolean isWindows() {
-			////System.out.println("OS name: "+getOsName());
+			log.debug("OS name: "+getOsName());
 			return getOsName().toLowerCase().startsWith("windows") ||getOsName().toLowerCase().startsWith("microsoft") || getOsName().toLowerCase().startsWith("ms");
 		}
 

--- a/src/main/java/gnu/io/RXTXCommDriver.java
+++ b/src/main/java/gnu/io/RXTXCommDriver.java
@@ -75,14 +75,18 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.TreeMap;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
    This is the JavaComm for Linux driver.
 */
 public class RXTXCommDriver implements CommDriver
 {
+	private static final Logger log = LoggerFactory.getLogger(RXTXCommDriver.class);
+
 	private static Set<String> ports =new HashSet<String>();
-	
-	private final static boolean debug = false;
+
 	private final static boolean devel = false;
 	private final static boolean noVersionOutput = "true".equals( System.getProperty( "gnu.io.rxtx.NoVersionOutput" ) );
 
@@ -90,7 +94,7 @@ public class RXTXCommDriver implements CommDriver
 	{
 		if(ports==null)
 			ports =new HashSet<String>();
-		if(debug ) System.out.println("RXTXCommDriver {}");
+		log.trace("RXTXCommDriver {}");
 		//System.loadLibrary( "rxtxSerial" );
 		SerialManager.getInstance();
 		/*
@@ -116,21 +120,18 @@ public class RXTXCommDriver implements CommDriver
 		{
 			if ( ! noVersionOutput )
 			{
-				System.out.println("Stable Library");
-				System.out.println("=========================================");
-				System.out.println("Native lib Version = " + LibVersion );
-				System.out.println("Java lib Version   = " + JarVersion );
+				log.info("Stable Library");
+				log.info("=========================================");
+				log.info("Native lib Version = " + LibVersion );
+				log.info("Java lib Version   = " + JarVersion );
 			}
 		}
 
 		if ( ! JarVersion.equals( LibVersion ) )
 		{
-			//System.out.println( "WARNING:  RXTX Version mismatch\n\tJar version = " + JarVersion + "\n\tnative lib Version = " + LibVersion );
+			//log.debug( "WARNING:  RXTX Version mismatch\n\tJar version = " + JarVersion + "\n\tnative lib Version = " + LibVersion );
 		}
-		else if ( debug )
-		{
-			System.out.println( "RXTXCommDriver:\n\tJar version = " + JarVersion + "\n\tnative lib Version = " + LibVersion );
-		}
+		log.debug( "RXTXCommDriver:\n\tJar version = " + JarVersion + "\n\tnative lib Version = " + LibVersion );
 	}
 
 	/** Get the Serial port prefixes for the running OS */
@@ -196,12 +197,10 @@ public class RXTXCommDriver implements CommDriver
 		*/
 
 		String ValidPortPrefixes[]=new String [getScannedBufferSize()];
-		if (debug)
-			System.out.println("\nRXTXCommDriver:getValidPortPrefixes()");
+		log.trace("\nRXTXCommDriver:getValidPortPrefixes()");
 		if(CandidatePortPrefixes==null)
 		{
-			if (debug)
-				System.out.println("\nRXTXCommDriver:getValidPortPrefixes() No ports prefixes known for this System.\nPlease check the port prefixes listed for " + osName + " in RXTXCommDriver:registerScannedPorts()\n");
+			log.debug("\nRXTXCommDriver:getValidPortPrefixes() No ports prefixes known for this System.\nPlease check the port prefixes listed for " + osName + " in RXTXCommDriver:registerScannedPorts()\n");
 		}
 		int i=0;
 		for(int j=0;j<CandidatePortPrefixes.length;j++){
@@ -214,25 +213,18 @@ public class RXTXCommDriver implements CommDriver
 		System.arraycopy(ValidPortPrefixes, 0, returnArray, 0, i);
 		if(ValidPortPrefixes[0]==null)
 		{
-			if (debug)
-			{
-				System.out.println("\nRXTXCommDriver:getValidPortPrefixes() No ports matched the list assumed for this\nSystem in the directory " + deviceDirectory + ".  Please check the ports listed for \"" + osName + "\" in\nRXTXCommDriver:registerScannedPorts()\nTried:");
-				for(int j=0;j<CandidatePortPrefixes.length;j++){
-					System.out.println("\t" +
-						CandidatePortPrefixes[i]);
-				}
+			log.debug("\nRXTXCommDriver:getValidPortPrefixes() No ports matched the list assumed for this\nSystem in the directory " + deviceDirectory + ".  Please check the ports listed for \"" + osName + "\" in\nRXTXCommDriver:registerScannedPorts()\nTried:");
+			for(int j=0;j<CandidatePortPrefixes.length;j++){
+				log.debug("\t" + CandidatePortPrefixes[i]);
 			}
 		}
 		else
 		{
-			if (debug)
-				System.out.println("\nRXTXCommDriver:getValidPortPrefixes()\nThe following port prefixes have been identified as valid on " + osName + ":\n");
+			log.debug("\nRXTXCommDriver:getValidPortPrefixes()\nThe following port prefixes have been identified as valid on " + osName + ":\n");
 /*
 			for(int j=0;j<returnArray.length;j++)
 			{
-				if (debug)
-					System.out.println("\t" + j + " " +
-						returnArray[j]);
+				log.debug("\t" + j + " " + returnArray[j]);
 			}
 */
 		}
@@ -286,20 +278,17 @@ public class RXTXCommDriver implements CommDriver
 			return;
 
 		}
-		
-		if (debug)
-		{
-			System.out.println("Entering registerValidPorts()");
-	/* */
-			System.out.println(" Candidate devices:");
-			for (int dn=0;dn<CandidateDeviceNames.length;dn++)
-				System.out.println("  "	+
-					CandidateDeviceNames[dn]);
-			System.out.println(" valid port prefixes:");
-			for (int pp=0;pp<ValidPortPrefixes.length;pp++)
-				System.out.println("  "+ValidPortPrefixes[pp]);
-	/* */
-		}
+
+		log.trace("Entering registerValidPorts()");
+		/* */
+		log.debug(" Candidate devices:");
+		for (int dn=0;dn<CandidateDeviceNames.length;dn++)
+			log.debug("  "+CandidateDeviceNames[dn]);
+		log.debug(" valid port prefixes:");
+		for (int pp=0;pp<ValidPortPrefixes.length;pp++)
+			log.debug("  "+ValidPortPrefixes[pp]);
+		/* */
+
 		if ( CandidateDeviceNames!=null && ValidPortPrefixes!=null)
 		{
 			for( i = 0;i<CandidateDeviceNames.length; i++ ) {
@@ -341,13 +330,8 @@ public class RXTXCommDriver implements CommDriver
 					{
 						PortName = C;
 					}
-					if (debug)
-					{
-						System.out.println( C +
-								" " + V );
-						System.out.println( CU +
-								" " + Cl );
-					}
+					log.debug( C + " " + V );
+					log.debug( CU + " " + Cl );
 					if( osName.equals("Solaris") ||
 						osName.equals("SunOS"))
 						checkSolaris(PortName,PortType);
@@ -372,8 +356,7 @@ public class RXTXCommDriver implements CommDriver
 				}
 			}
 		}
-		if (debug)
-			System.out.println("Leaving registerValidPorts()");
+		log.trace("Leaving registerValidPorts()");
 	}
 
 
@@ -405,7 +388,7 @@ public class RXTXCommDriver implements CommDriver
 	public void initialize()
 	{
 
-		if (debug) System.out.println("RXTXCommDriver:initialize()");
+		log.trace("RXTXCommDriver:initialize()");
 
 		osName=System.getProperty("os.name");
 		deviceDirectory=getDeviceDirectory();
@@ -428,8 +411,7 @@ public class RXTXCommDriver implements CommDriver
 		final String pathSep = System.getProperty("path.separator", ":");
 		final StringTokenizer tok = new StringTokenizer(names, pathSep);
 
-		if (debug)
-			System.out.println("\nRXTXCommDriver:addSpecifiedPorts()");
+		log.trace("\nRXTXCommDriver:addSpecifiedPorts()");
 		while (tok.hasMoreElements())
 		{
 			String PortName = tok.nextToken();
@@ -476,16 +458,11 @@ public class RXTXCommDriver implements CommDriver
 		          System.setProperty(key, p.getProperty(key));
 		     }
 		    }catch(Exception e){
-			if (debug){
-			    System.out.println("The file: gnu.io.rxtx.properties doesn't exists.");
-			    System.out.println(e.toString());
-			    }//end if
+				log.error("The file: gnu.io.rxtx.properties doesn't exists.", e);
 			}//end catch
 
-		if (debug)
-			System.out.println("checking for system-known ports of type "+PortType);
-		if (debug)
-			System.out.println("checking registry for ports of type "+PortType);
+		log.debug("checking for system-known ports of type "+PortType);
+		log.debug("checking registry for ports of type "+PortType);
 
 		switch (PortType) {
 			case CommPortIdentifier.PORT_SERIAL:
@@ -498,8 +475,7 @@ public class RXTXCommDriver implements CommDriver
 				val = System.getProperty("gnu.io.ParallelPorts");
 				break;
 			default:
-				if (debug)
-				System.out.println("unknown port type "+PortType+" passed to RXTXCommDriver.registerSpecifiedPorts()");
+				log.debug("unknown port type "+PortType+" passed to RXTXCommDriver.registerSpecifiedPorts()");
 		}
 
 		System.setProperties(origp); //recall saved properties
@@ -525,8 +501,7 @@ public class RXTXCommDriver implements CommDriver
 		osName=System.getProperty("os.name");
 		deviceDirectory=getDeviceDirectory();
 		String[] CandidateDeviceNames;
-		if (debug)
-			System.out.println("scanning device directory "+deviceDirectory+" for ports of type "+PortType);
+		log.debug("scanning device directory "+deviceDirectory+" for ports of type "+PortType);
 		
 		boolean performTestRead = true;
 		
@@ -542,8 +517,7 @@ public class RXTXCommDriver implements CommDriver
 					useFallback = false;
 				}
 				catch (Throwable ex) {
-					if (debug)
-						System.err.println("Error reading the registry to get port list " + ex.getMessage());					
+					log.debug("Error reading the registry to get port list " + ex.getMessage());					
 				}
 			}
 
@@ -582,7 +556,7 @@ public class RXTXCommDriver implements CommDriver
 						deva.length, devb.length );
 				if( debug ) {
 					for( int j = 0; j< temp.length;j++)
-						System.out.println( temp[j] );
+						log.debug( temp[j] );
 				}
 				CandidateDeviceNames=temp;
 	*/
@@ -621,16 +595,14 @@ public class RXTXCommDriver implements CommDriver
 			}
 			if (CandidateDeviceNames==null)
 			{
-				if (debug)
-					System.out.println("RXTXCommDriver:registerScannedPorts() no Device files to check ");
+				log.debug("RXTXCommDriver:registerScannedPorts() no Device files to check ");
 				return;
 			}
 
 			String CandidatePortPrefixes[] = {};
 			switch (PortType) {
 				case CommPortIdentifier.PORT_SERIAL:
-					if (debug)
-						System.out.println("scanning for serial ports for os "+osName);
+					log.debug("scanning for serial ports for os "+osName);
 
 
 			/*  There are _many_ possible ports that can be used
@@ -872,14 +844,12 @@ public class RXTXCommDriver implements CommDriver
 				}
 				else
 				{
-					if (debug)
-						System.out.println("No valid prefixes for serial ports have been entered for "+osName + " in RXTXCommDriver.java.  This may just be a typo in the method registerScanPorts().");
+					log.debug("No valid prefixes for serial ports have been entered for "+osName + " in RXTXCommDriver.java.  This may just be a typo in the method registerScanPorts().");
 				}
 				break;
 
 			case CommPortIdentifier.PORT_PARALLEL:
-				if (debug)
-					System.out.println("scanning for parallel ports for os "+osName);
+				log.debug("scanning for parallel ports for os "+osName);
 			/** Get the Parallel port prefixes for the running os
 			* Holger Lehmann
 			* July 12, 1999
@@ -921,8 +891,7 @@ public class RXTXCommDriver implements CommDriver
 				}
 				break;
 			default:
-				if (debug)
-					System.out.println("Unknown PortType "+PortType+" passed to RXTXCommDriver.registerScannedPorts()");
+				log.debug("Unknown PortType "+PortType+" passed to RXTXCommDriver.registerScannedPorts()");
 		}
 		registerValidPorts(CandidateDeviceNames, CandidatePortPrefixes, PortType, performTestRead);
 	}
@@ -972,8 +941,7 @@ public class RXTXCommDriver implements CommDriver
 	*/
 	public CommPort getCommPort( String PortName, int PortType )
 	{
-		if (debug) System.out.println("RXTXCommDriver:getCommPort("
-			+PortName+","+PortType+")");
+		log.trace("RXTXCommDriver:getCommPort("+PortName+","+PortType+")");
 		try {
 			switch (PortType) {
 				case CommPortIdentifier.PORT_SERIAL:
@@ -987,13 +955,10 @@ public class RXTXCommDriver implements CommDriver
 						return new RXTXPort( deviceDirectory + PortName );
 					}
 				default:
-					if (debug)
-						System.out.println("unknown PortType  "+PortType+" passed to RXTXCommDriver.getCommPort()");
+					log.debug("unknown PortType  "+PortType+" passed to RXTXCommDriver.getCommPort()");
 			}
 		} catch( PortInUseException e ) {
-			if (debug)
-				System.out.println(
-					"Port "+PortName+" in use by another application");
+			log.error("Port "+PortName+" in use by another application");
 		}
 		return null;
 	}
@@ -1001,6 +966,6 @@ public class RXTXCommDriver implements CommDriver
 	/*  Yikes.  Trying to call println from C for odd reasons */
 	public void Report( String arg )
 	{
-		System.out.println(arg);
+		log.debug(arg);
 	}
 }

--- a/src/main/java/gnu/io/RXTXCommDriver.java
+++ b/src/main/java/gnu/io/RXTXCommDriver.java
@@ -96,7 +96,6 @@ public class RXTXCommDriver implements CommDriver
 	{
 		if(ports==null)
 			ports =new HashSet<String>();
-		log.trace("RXTXCommDriver {}");
 		//System.loadLibrary( "rxtxSerial" );
 		SerialManager.getInstance();
 		/*
@@ -118,22 +117,6 @@ public class RXTXCommDriver implements CommDriver
 			// for rxtx prior to 2.1.7
 			LibVersion = nativeGetVersion();
 		}
-		if ( devel )
-		{
-			if ( ! noVersionOutput )
-			{
-				log.info("Stable Library");
-				log.info("=========================================");
-				log.info("Native lib Version = " + LibVersion );
-				log.info("Java lib Version   = " + JarVersion );
-			}
-		}
-
-		if ( ! JarVersion.equals( LibVersion ) )
-		{
-			//log.debug( "WARNING:  RXTX Version mismatch\n\tJar version = " + JarVersion + "\n\tnative lib Version = " + LibVersion );
-		}
-		log.debug( "RXTXCommDriver:\n\tJar version = " + JarVersion + "\n\tnative lib Version = " + LibVersion );
 	}
 
 	/** Get the Serial port prefixes for the running OS */
@@ -199,10 +182,10 @@ public class RXTXCommDriver implements CommDriver
 		*/
 
 		String ValidPortPrefixes[]=new String [getScannedBufferSize()];
-		log.trace("\nRXTXCommDriver:getValidPortPrefixes()");
+		log.trace("RXTXCommDriver:getValidPortPrefixes()");
 		if(CandidatePortPrefixes==null)
 		{
-			log.debug("\nRXTXCommDriver:getValidPortPrefixes() No ports prefixes known for this System.\nPlease check the port prefixes listed for " + osName + " in RXTXCommDriver:registerScannedPorts()\n");
+			log.debug("RXTXCommDriver:getValidPortPrefixes() No ports prefixes known for this System. Please check the port prefixes listed for {} in RXTXCommDriver:registerScannedPorts()", osName);
 		}
 		int i=0;
 		for(int j=0;j<CandidatePortPrefixes.length;j++){
@@ -215,21 +198,10 @@ public class RXTXCommDriver implements CommDriver
 		System.arraycopy(ValidPortPrefixes, 0, returnArray, 0, i);
 		if(ValidPortPrefixes[0]==null)
 		{
-			log.debug("\nRXTXCommDriver:getValidPortPrefixes() No ports matched the list assumed for this\nSystem in the directory " + deviceDirectory + ".  Please check the ports listed for \"" + osName + "\" in\nRXTXCommDriver:registerScannedPorts()\nTried:");
-			for(int j=0;j<CandidatePortPrefixes.length;j++){
-				log.debug("\t" + CandidatePortPrefixes[i]);
-			}
+			log.debug("RXTXCommDriver:getValidPortPrefixes() No ports matched the list assumed for this System in the directory {}. Please check the ports listed for \"{}\" in RXTXCommDriver:registerScannedPorts(). Tried: {}",
+			deviceDirectory, osName, String.join(", ", CandidatePortPrefixes));
 		}
-		else
-		{
-			log.debug("\nRXTXCommDriver:getValidPortPrefixes()\nThe following port prefixes have been identified as valid on " + osName + ":\n");
-/*
-			for(int j=0;j<returnArray.length;j++)
-			{
-				log.debug("\t" + j + " " + returnArray[j]);
-			}
-*/
-		}
+
 		return returnArray;
 	}
 
@@ -281,15 +253,10 @@ public class RXTXCommDriver implements CommDriver
 
 		}
 
-		log.trace("Entering registerValidPorts()");
-		/* */
-		log.debug(" Candidate devices:");
-		for (int dn=0;dn<CandidateDeviceNames.length;dn++)
-			log.debug("  "+CandidateDeviceNames[dn]);
-		log.debug(" valid port prefixes:");
-		for (int pp=0;pp<ValidPortPrefixes.length;pp++)
-			log.debug("  "+ValidPortPrefixes[pp]);
-		/* */
+		log.trace("RegisterValidPorts: Candidates: {}", String.join(", ", CandidateDeviceNames));
+		log.trace("RegisterValidPorts: Port prefixes: {}",  String.join(", ", ValidPortPrefixes));
+
+		List<String> foundDevices = new ArrayList<>();
 
 		if ( CandidateDeviceNames!=null && ValidPortPrefixes!=null)
 		{
@@ -332,8 +299,7 @@ public class RXTXCommDriver implements CommDriver
 					{
 						PortName = C;
 					}
-					log.debug( C + " " + V );
-					log.debug( CU + " " + Cl );
+					foundDevices.add(C);
 					if( osName.equals("Solaris") ||
 						osName.equals("SunOS"))
 						checkSolaris(PortName,PortType);
@@ -358,6 +324,7 @@ public class RXTXCommDriver implements CommDriver
 				}
 			}
 		}
+		log.trace("Found Devices: {}", String.join(", ", foundDevices));
 		log.trace("Leaving registerValidPorts()");
 	}
 
@@ -413,7 +380,6 @@ public class RXTXCommDriver implements CommDriver
 		final String pathSep = System.getProperty("path.separator", ":");
 		final StringTokenizer tok = new StringTokenizer(names, pathSep);
 
-		log.trace("\nRXTXCommDriver:addSpecifiedPorts()");
 		while (tok.hasMoreElements())
 		{
 			String PortName = tok.nextToken();
@@ -460,13 +426,10 @@ public class RXTXCommDriver implements CommDriver
 		          System.setProperty(key, p.getProperty(key));
 		     }
 		} catch (FileNotFoundException e) {
-			log.debug("The file gnu.io.rxtx.properties doesn't exist.");
+			log.trace("Skip reading config from gnu.io.rxtx.properties: File does not exist");
 		} catch (IOException e) {
 			log.error("Error opening file gnu.io.rxtx.properties:", e);
 		}
-
-		log.debug("checking for system-known ports of type "+PortType);
-		log.debug("checking registry for ports of type "+PortType);
 
 		switch (PortType) {
 			case CommPortIdentifier.PORT_SERIAL:
@@ -479,7 +442,7 @@ public class RXTXCommDriver implements CommDriver
 				val = System.getProperty("gnu.io.ParallelPorts");
 				break;
 			default:
-				log.debug("unknown port type "+PortType+" passed to RXTXCommDriver.registerSpecifiedPorts()");
+				log.error("Unknown port type "+PortType+" passed to RXTXCommDriver.registerSpecifiedPorts()");
 		}
 
 		System.setProperties(origp); //recall saved properties
@@ -505,7 +468,7 @@ public class RXTXCommDriver implements CommDriver
 		osName=System.getProperty("os.name");
 		deviceDirectory=getDeviceDirectory();
 		String[] CandidateDeviceNames;
-		log.debug("scanning device directory "+deviceDirectory+" for ports of type "+PortType);
+		log.trace("Scanning device directory "+deviceDirectory+" for ports of type "+PortType);
 		
 		boolean performTestRead = true;
 		
@@ -521,7 +484,7 @@ public class RXTXCommDriver implements CommDriver
 					useFallback = false;
 				}
 				catch (Throwable ex) {
-					log.debug("Error reading the registry to get port list " + ex.getMessage());					
+					log.debug("Error reading the registry to get port list: {}", ex.getMessage());
 				}
 			}
 
@@ -606,9 +569,6 @@ public class RXTXCommDriver implements CommDriver
 			String CandidatePortPrefixes[] = {};
 			switch (PortType) {
 				case CommPortIdentifier.PORT_SERIAL:
-					log.debug("scanning for serial ports for os "+osName);
-
-
 			/*  There are _many_ possible ports that can be used
 			    on Linux.  See below in the fake Linux-all-ports  
 			    case for a list.  You may add additional ports
@@ -853,7 +813,7 @@ public class RXTXCommDriver implements CommDriver
 				break;
 
 			case CommPortIdentifier.PORT_PARALLEL:
-				log.debug("scanning for parallel ports for os "+osName);
+				log.debug("Scanning for parallel ports for os "+osName);
 			/** Get the Parallel port prefixes for the running os
 			* Holger Lehmann
 			* July 12, 1999
@@ -959,10 +919,10 @@ public class RXTXCommDriver implements CommDriver
 						return new RXTXPort( deviceDirectory + PortName );
 					}
 				default:
-					log.debug("unknown PortType  "+PortType+" passed to RXTXCommDriver.getCommPort()");
+					log.debug("Unknown PortType  "+PortType+" passed to RXTXCommDriver.getCommPort()");
 			}
 		} catch( PortInUseException e ) {
-			log.error("Port "+PortName+" in use by another application");
+			log.warn("Port "+PortName+" in use by another application");
 		}
 		return null;
 	}

--- a/src/main/java/gnu/io/RXTXCommDriver.java
+++ b/src/main/java/gnu/io/RXTXCommDriver.java
@@ -65,6 +65,8 @@ package gnu.io;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -457,9 +459,11 @@ public class RXTXCommDriver implements CommDriver
 		          String key = (String) it.next();
 		          System.setProperty(key, p.getProperty(key));
 		     }
-		    }catch(Exception e){
-				log.error("The file: gnu.io.rxtx.properties doesn't exists.", e);
-			}//end catch
+		} catch (FileNotFoundException e) {
+			log.debug("The file gnu.io.rxtx.properties doesn't exist.");
+		} catch (IOException e) {
+			log.error("Error opening file gnu.io.rxtx.properties:", e);
+		}
 
 		log.debug("checking for system-known ports of type "+PortType);
 		log.debug("checking registry for ports of type "+PortType);

--- a/src/main/java/gnu/io/RXTXPort.java
+++ b/src/main/java/gnu/io/RXTXPort.java
@@ -96,10 +96,6 @@ public class RXTXPort extends SerialPort
 		private volatile boolean Data=false;
 		private volatile boolean Output=false;
 
-		MonitorThread() 
-		{
-			log.trace( "RXTXPort:MonitorThread:MonitorThread()"); 
-		}
 	/**
 	*  run the thread and call the event loop.
 	*/
@@ -110,7 +106,7 @@ public class RXTXPort extends SerialPort
 				monThreadisInterrupted=false;
 				eventLoop();
 	            eis = 0;
-				log.error( "eventLoop() returned, this is invalid."); 
+				log.trace( "eventLoop() finished");
 			}catch(Throwable ex) {
 				HARDWARE_FAULT=true;
 				sendEvent(SerialPortEvent.HARDWARE_ERROR, true);
@@ -206,7 +202,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public OutputStream getOutputStream()
 	{
-		log.trace( "RXTXPort:getOutputStream() called and returning");
 		return out;
 	}
 
@@ -219,7 +214,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public InputStream getInputStream()
 	{
-		log.trace( "RXTXPort:getInputStream() called and returning");
 		return in;
 	}
 
@@ -274,7 +268,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public int getBaudRate()
 	{
-		log.trace( "RXTXPort:getBaudRate() called and returning " + speed);
 		return speed;
 	}
 
@@ -285,7 +278,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public int getDataBits()
 	{
-		log.trace( "RXTXPort:getDataBits() called and returning " + dataBits);
 		return dataBits;
 	}
 
@@ -296,7 +288,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public int getStopBits()
 	{
-		log.trace( "RXTXPort:getStopBits() called and returning " + stopBits);
 		return stopBits;
 	}
 
@@ -307,7 +298,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public int getParity()
 	{
-		log.trace( "RXTXPort:getParity() called and returning " + parity );
 		return parity;
 	}
 
@@ -323,7 +313,7 @@ public class RXTXPort extends SerialPort
 		log.trace( "RXTXPort:setFlowControlMode( " + flowcontrol + " ) called");
 		if(monThreadisInterrupted) 
 		{
-			log.trace(  "RXTXPort:setFlowControlMode MonThread is Interrupeted returning" );
+			log.trace(  "RXTXPort:setFlowControlMode MonThread was interrupted" );
 			return;
 		}
 		try {
@@ -342,7 +332,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public int getFlowControlMode()
 	{
-		log.trace( "RXTXPort:getFlowControlMode() returning " + flowmode );
 		return flowmode;
 	}
 	native void setflowcontrol( int flowcontrol ) throws IOException;
@@ -360,7 +349,6 @@ public class RXTXPort extends SerialPort
 	public void enableReceiveFraming( int f )
 		throws UnsupportedCommOperationException
 	{
-		log.trace( "RXTXPort:enableReceiveFramming() throwing exception");
 		throw new UnsupportedCommOperationException( "Not supported" );
 	}
 	/** 
@@ -374,7 +362,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public boolean isReceiveFramingEnabled()
 	{
-		log.trace( "RXTXPort:isReceiveFrammingEnabled() called and returning " + false );
 		return false;
 	}
 	/** 
@@ -382,7 +369,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public int getReceiveFramingByte()
 	{
-		log.trace( "RXTXPort:getReceiveFrammingByte() called and returning " + 0 );
 		return 0;
 	}
 
@@ -441,7 +427,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public boolean isReceiveTimeoutEnabled()
 	{
-		log.trace( "RXTXPort:isReceiveTimeoutEnabled() called and returning " + NativeisReceiveTimeoutEnabled() );
 		return( NativeisReceiveTimeoutEnabled() );
 	}
 	/** 
@@ -449,7 +434,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public int getReceiveTimeout()
 	{
-		log.trace( "RXTXPort:getReceiveTimeout() called and returning " + NativegetReceiveTimeout() );
 		return(NativegetReceiveTimeout( ));
 	}
 
@@ -482,7 +466,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public void disableReceiveThreshold()
 	{
-		log.trace( "RXTXPort:disableReceiveThreshold() called and returning");
 		enableReceiveThreshold(0);
 	}
 	/** 
@@ -490,7 +473,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public int getReceiveThreshold()
 	{
-		log.trace( "RXTXPort:getReceiveThreshold() called and returning " + threshold);
 		return threshold;
 	}
 	/** 
@@ -498,7 +480,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public boolean isReceiveThresholdEnabled()
 	{
-		log.trace( "RXTXPort:isReceiveThresholdEnable() called and returning" + (threshold > 0) );
 		return(threshold>0);
 	}
 
@@ -529,7 +510,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public int getInputBufferSize()
 	{
-		log.trace( "RXTXPort:getInputBufferSize() called and returning " + InputBuffer );
 		return(InputBuffer);
 	}
 	/** 
@@ -552,7 +532,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public int getOutputBufferSize()
 	{
-		log.trace( "RXTXPort:getOutputBufferSize() called and returning " + OutputBuffer );
 		return(OutputBuffer);
 	}
 
@@ -648,7 +627,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public boolean sendEvent( int event, boolean state )
 	{
-		log.trace( "RXTXPort:sendEvent(");
 		/* Let the native side know its time to die */
 
 		if ( fd == 0 || SPEventListener == null || monThread == null)
@@ -659,43 +637,43 @@ public class RXTXPort extends SerialPort
 		switch( event )
 		{
 			case SerialPortEvent.HARDWARE_ERROR:
-			log.debug( "HARDWARE_ERROR " +
+			log.warn( "RXTXPort:sendEvent: HARDWARE_ERROR " +
 					monThread.Data + ")" );
-			break;case SerialPortEvent.DATA_AVAILABLE:
-				log.debug( "DATA_AVAILABLE " + monThread.Data + ")" );
+			break;
+			case SerialPortEvent.DATA_AVAILABLE:
+				log.trace( "RXTXPort:sendEvent: DATA_AVAILABLE " + monThread.Data);
 				break;
 			case SerialPortEvent.OUTPUT_BUFFER_EMPTY:
-				log.debug( "OUTPUT_BUFFER_EMPTY " + monThread.Output + ")" );
+				log.trace( "RXTXPort:sendEvent: OUTPUT_BUFFER_EMPTY " + monThread.Output);
 				break;
 			case SerialPortEvent.CTS:
-				log.debug( "CTS " + monThread.CTS + ")" );
+				log.trace( "RXTXPort:sendEvent: CTS " + monThread.CTS);
 				break;
 			case SerialPortEvent.DSR:
-				log.debug( "DSR " + monThread.Output + ")" );
+				log.trace( "RXTXPort:sendEvent: DSR " + monThread.Output);
 				break;
 			case SerialPortEvent.RI:
-				log.debug( "RI " + monThread.RI + ")" );
+				log.trace( "RXTXPort:sendEvent: RI " + monThread.RI);
 				break;
 			case SerialPortEvent.CD:
-				log.debug( "CD " + monThread.CD + ")" );
+				log.trace( "RXTXPort:sendEvent: CD " + monThread.CD);
 				break;
 			case SerialPortEvent.OE:
-				log.debug( "OE " + monThread.OE + ")" );
+				log.trace( "RXTXPort:sendEvent: OE " + monThread.OE);
 				break;
 			case SerialPortEvent.PE:
-				log.debug( "PE " + monThread.PE + ")" );
+				log.trace( "RXTXPort:sendEvent: PE " + monThread.PE);
 				break;
 			case SerialPortEvent.FE:
-				log.debug( "FE " + monThread.FE + ")" );
+				log.trace( "RXTXPort:sendEvent: FE " + monThread.FE);
 				break;
 			case SerialPortEvent.BI:
-				log.debug( "BI " + monThread.BI + ")" );
+				log.trace( "RXTXPort:sendEvent: BI " + monThread.BI);
 				break;
 			default:
-				log.debug( "XXXXXXXXXXXXXX " + event + ")" );
+				log.debug( "RXTXPort:sendEvent: " + event);
 				break;
 		}
-		log.trace(  "	checking flags " );
 
 		switch( event )
 		{
@@ -732,24 +710,18 @@ public class RXTXPort extends SerialPort
 			case SerialPortEvent.HARDWARE_ERROR:
 				break;
 			default:
-				log.debug( "unknown event: " + event);
 				return(false);
 		}
-		log.trace(  "	getting event" );
 		SerialPortEvent e = new SerialPortEvent(this, event, !state,
 			state );
-		log.trace(  "	sending event" );
 		if(monThreadisInterrupted) 
 		{
-			log.trace(  "	sendEvent return" );
 			return(true);
 		}
 		if( SPEventListener != null )
 		{
 			SPEventListener.serialEvent( e );
 		}
-
-		log.trace(  "	sendEvent return" );
 
 		if (fd == 0 ||  SPEventListener == null || monThread == null) 
 		{
@@ -833,7 +805,7 @@ public class RXTXPort extends SerialPort
  			}
 				
 			if (monThread.isAlive()) {
-				log.debug( "	MonThread is still alive!");
+				log.warn( "Failed to cancel monitor thread");
 			}
 			
 		}
@@ -869,8 +841,6 @@ public class RXTXPort extends SerialPort
 						boolean flag );
 	public void notifyOnDataAvailable( boolean enable )
 	{
-		log.trace( "RXTXPort:notifyOnDataAvailable( " + enable+" )");
-		
 		waitForTheNativeCodeSilly();
 
 		MonitorThreadLock = true;
@@ -885,7 +855,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public void notifyOnOutputEmpty( boolean enable )
 	{
-		log.trace( "RXTXPort:notifyOnOutputEmpty( " + enable+" )");
 		waitForTheNativeCodeSilly();
 		MonitorThreadLock = true;
 		nativeSetEventFlag( fd, SerialPortEvent.OUTPUT_BUFFER_EMPTY,
@@ -899,7 +868,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public void notifyOnCTS( boolean enable )
 	{
-		log.trace( "RXTXPort:notifyOnCTS( " + enable+" )");
 		waitForTheNativeCodeSilly();
 		MonitorThreadLock = true;
 		nativeSetEventFlag( fd, SerialPortEvent.CTS, enable );
@@ -911,7 +879,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public void notifyOnDSR( boolean enable )
 	{
-		log.trace( "RXTXPort:notifyOnDSR( " + enable+" )");
 		waitForTheNativeCodeSilly();
 		MonitorThreadLock = true;
 		nativeSetEventFlag( fd, SerialPortEvent.DSR, enable );
@@ -923,7 +890,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public void notifyOnRingIndicator( boolean enable )
 	{
-		log.trace( "RXTXPort:notifyOnRingIndicator( " + enable+" )");
 		waitForTheNativeCodeSilly();
 		MonitorThreadLock = true;
 		nativeSetEventFlag( fd, SerialPortEvent.RI, enable );
@@ -935,7 +901,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public void notifyOnCarrierDetect( boolean enable )
 	{
-		log.trace( "RXTXPort:notifyOnCarrierDetect( " + enable+" )");
 		waitForTheNativeCodeSilly();
 		MonitorThreadLock = true;
 		nativeSetEventFlag( fd, SerialPortEvent.CD, enable );
@@ -947,7 +912,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public void notifyOnOverrunError( boolean enable )
 	{
-		log.trace( "RXTXPort:notifyOnOverrunError( " + enable+" )");
 		waitForTheNativeCodeSilly();
 		MonitorThreadLock = true;
 		nativeSetEventFlag( fd, SerialPortEvent.OE, enable );
@@ -959,7 +923,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public void notifyOnParityError( boolean enable )
 	{
-		log.trace( "RXTXPort:notifyOnParityError( " + enable+" )");
 		waitForTheNativeCodeSilly();
 		MonitorThreadLock = true;
 		nativeSetEventFlag( fd, SerialPortEvent.PE, enable );
@@ -971,7 +934,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public void notifyOnFramingError( boolean enable )
 	{
-		log.trace( "RXTXPort:notifyOnFramingError( " + enable+" )");
 		waitForTheNativeCodeSilly();
 		MonitorThreadLock = true;
 		nativeSetEventFlag( fd, SerialPortEvent.FE, enable );
@@ -983,7 +945,6 @@ public class RXTXPort extends SerialPort
 	*/
 	public void notifyOnBreakInterrupt( boolean enable )
 	{
-		log.trace( "RXTXPort:notifyOnBreakInterrupt( " + enable+" )");
 		waitForTheNativeCodeSilly();
 		MonitorThreadLock = true;
 		nativeSetEventFlag( fd, SerialPortEvent.BI, enable );
@@ -996,7 +957,8 @@ public class RXTXPort extends SerialPort
 
     public void close()
 	{
-                log.trace( "RXTXPort:close( " + this.name + " )"); 
+				log.trace( "RXTXPort:close( " + this.name + " )");
+				log.debug("Closing port: {}", name);
 
                 try {
                         while( !IOLockedMutex.writeLock().tryLock(500, TimeUnit.MILLISECONDS) )
@@ -1033,7 +995,8 @@ public class RXTXPort extends SerialPort
                 {
                     if (IOLockedMutex.writeLock().isHeldByCurrentThread()) {
                         IOLockedMutex.writeLock().unlock();
-                    }
+					}
+					log.debug("Closed port: {}", name);
                 }
 
 	}
@@ -1049,6 +1012,41 @@ public class RXTXPort extends SerialPort
 			close();
 		}
 		z.finalize();
+	}
+
+	private String getParityAsString() {
+		switch(parity) {
+			case PARITY_NONE:
+				return "N";
+			case PARITY_ODD:
+				return "O";
+			case PARITY_EVEN:
+				return "E";
+			case PARITY_MARK:
+				return "M";
+			case PARITY_SPACE:
+				return "S";
+			default:
+				return "?";
+		}
+	}
+
+	private String getStopBitsAsString() {
+		switch(stopBits) {
+			case STOPBITS_1:
+				return "1";
+			case STOPBITS_1_5:
+				return "1.5";
+			case STOPBITS_2:
+				return "2";
+			default:
+				return "?";
+		}
+	}
+
+	@Override
+	public String toString() {
+		return speed + " " + dataBits + getParityAsString() + getStopBitsAsString();
 	}
 
 	/** Inner class for SerialOutputStream */
@@ -1189,20 +1187,15 @@ public class RXTXPort extends SerialPort
 	*/
 		public synchronized int read() throws IOException
 		{
-			log.trace( "RXTXPort:SerialInputStream:read() called");
 			if ( fd == 0 ) throw new IOException();
 			if ( monThreadisInterrupted )
 			{
-				log.debug( "+++++++++ read() monThreadisInterrupted" );
+				log.debug( "read(): monThreadisInterrupted" );
 			}
 			IOLockedMutex.readLock().lock();
 			try {
-				log.trace(  "RXTXPort:SerialInputStream:read() L" );
 				waitForTheNativeCodeSilly();
-				log.trace(  "RXTXPort:SerialInputStream:read() N" );
 				int result = readByte();
-				//log.trace(  "RXTXPort:SerialInputStream:read() returns byte = " + result );
-				log.trace(  "RXTXPort:SerialInputStream:read() returns" );
 				return( result );
 			}				
 			finally
@@ -1226,7 +1219,6 @@ public class RXTXPort extends SerialPort
 		public synchronized int read( byte b[] ) throws IOException
 		{
 			int result;
-			log.trace( "RXTXPort:SerialInputStream:read(" + b.length + ") called");
 			if ( monThreadisInterrupted == true )
 			{
 				return(0);
@@ -1236,7 +1228,6 @@ public class RXTXPort extends SerialPort
 			{
 				waitForTheNativeCodeSilly();
 				result = read( b, 0, b.length);
-				log.trace(  "RXTXPort:SerialInputStream:read() returned " + result + " bytes" );
 				return( result );
 			}
 			finally
@@ -1267,30 +1258,23 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 		public synchronized int read( byte b[], int off, int len )
 			throws IOException
 		{
-			log.trace( "RXTXPort:SerialInputStream:read(" + b.length + " " + off + " " + len + ") called" /*+ new String(b) */ );
 			int result;
 			/*
 			 * Some sanity checks
 			 */
 			if ( fd == 0 )
 			{
-				log.trace( "RXTXPort:SerialInputStream:read() fd == 0");
-				log.debug("+++++++ IOException()\n");
 				throw new IOException();
 			}
 
 			if( b==null )
 			{
-				log.debug("+++++++ NullPointerException()\n");
-				log.trace( "RXTXPort:SerialInputStream:read() b == 0");
-				throw new NullPointerException();
+				throw new NullPointerException("Input byte array is null");
 			}
 
 			if( (off < 0) || (len < 0) || (off+len > b.length))
 			{
-				log.debug("+++++++ IndexOutOfBoundsException()\n");
-				log.trace( "RXTXPort:SerialInputStream:read() off < 0 ..");
-				throw new IndexOutOfBoundsException();
+				throw new IndexOutOfBoundsException("Offset: " + off + " Length: " + len + " Data length: " + b.length);
 			}
 
 			/*
@@ -1298,7 +1282,6 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 			 */
 			if( len==0 )
 			{
-				log.trace( "RXTXPort:SerialInputStream:read() len == 0");
 				return 0;
 			}
 			/*
@@ -1340,7 +1323,6 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 			{
 				waitForTheNativeCodeSilly();
 				result = readArray( b, off, Minimum);
-				log.trace( "RXTXPort:SerialInputStream:read(" + b.length + " " + off + " " + len + ") returned " + result + " bytes"  /*+ new String(b) */);
 				return( result );
 			}
 			finally
@@ -1376,23 +1358,17 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 			 */
 			if ( fd == 0 )
 			{
-				log.trace( "RXTXPort:SerialInputStream:read() fd == 0");
-				log.debug("+++++++ IOException()\n");
 				throw new IOException();
 			}
 
 			if( b==null )
 			{
-				log.debug("+++++++ NullPointerException()\n");
-				log.trace( "RXTXPort:SerialInputStream:read() b == 0");
-				throw new NullPointerException();
+				throw new NullPointerException("Input byte array is null");
 			}
 
 			if( (off < 0) || (len < 0) || (off+len > b.length))
 			{
-				log.debug("+++++++ IndexOutOfBoundsException()\n");
-				log.trace( "RXTXPort:SerialInputStream:read() off < 0 ..");
-				throw new IndexOutOfBoundsException();
+				throw new IndexOutOfBoundsException("Offset: " + off + " Length: " + len + " Data length: " + b.length);
 			}
 
 			/*
@@ -1400,7 +1376,6 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 			 */
 			if( len==0 )
 			{
-				log.trace( "RXTXPort:SerialInputStream:read() len == 0");
 				return 0;
 			}
 			/*
@@ -1442,7 +1417,6 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 			{
 				waitForTheNativeCodeSilly();
 				result = readTerminatedArray( b, off, Minimum, t );
-				log.trace( "RXTXPort:SerialInputStream:read(" + b.length + " " + off + " " + len + ") returned " + result + " bytes"  /*+ new String(b) */);
 				return( result );
 			}
 			finally
@@ -1460,12 +1434,10 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 			{
 				return(0);
 			}
-			log.trace( "RXTXPort:available() called" );
 			IOLockedMutex.readLock().lock();
 			try
 			{
 				int r = nativeavailable();
-				log.trace( "RXTXPort:available() returning " + r );
 				return r;
 			}
 			finally
@@ -1566,7 +1538,6 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public static int staticGetBaudRate( String port )
 		throws UnsupportedCommOperationException
 	{
-		log.trace("RXTXPort:staticGetBaudRate( " + port + " )");
 		return(nativeStaticGetBaudRate( port ));
 	}
 	/**
@@ -1582,7 +1553,6 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public static int staticGetDataBits( String port )
 		throws UnsupportedCommOperationException
 	{
-		log.trace("RXTXPort:staticGetDataBits( " + port + " )");
 		return(nativeStaticGetDataBits( port ) );
 	}
 
@@ -1599,7 +1569,6 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public static int staticGetParity( String port )
 		throws UnsupportedCommOperationException
 	{
-		log.trace("RXTXPort:staticGetParity( " + port + " )");
 		return( nativeStaticGetParity( port ) );
 	}
 
@@ -1616,7 +1585,6 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public static int staticGetStopBits( String port )
 		throws UnsupportedCommOperationException
 	{
-		log.trace("RXTXPort:staticGetStopBits( " + port + " )");
 		return(nativeStaticGetStopBits( port ) );
 	}
 
@@ -1839,9 +1807,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 		throws UnsupportedCommOperationException
 	{
 		byte ret;
-		log.trace(  "getParityErrorChar()" );
 		ret = nativeGetParityErrorChar();
-		log.trace(  "getParityErrorChar() returns " + ret );
 		return( ret );
 	}
 
@@ -1877,9 +1843,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 		throws UnsupportedCommOperationException
 	{
 		byte ret;
-		log.trace(  "getEndOfInputChar()" );
 		ret = nativeGetEndOfInputChar();
-		log.trace(  "getEndOfInputChar() returns " + ret );
 		return( ret );
 	}
 
@@ -1956,7 +1920,6 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public int getBaudBase() throws UnsupportedCommOperationException,
 		IOException
 	{
-		log.trace(  "RXTXPort:getBaudBase()");
 		return nativeGetBaudBase();
 	}
 
@@ -1970,7 +1933,6 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public boolean setDivisor(int Divisor)
 		throws UnsupportedCommOperationException, IOException
 	{
-		log.trace(  "RXTXPort:setDivisor()");
 		return nativeSetDivisor(Divisor);
 	}
 
@@ -1983,7 +1945,6 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public int getDivisor() throws UnsupportedCommOperationException,
 		IOException
 	{
-		log.trace(  "RXTXPort:getDivisor()");
 		return nativeGetDivisor();
 	}
 
@@ -1995,7 +1956,6 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 
 	public boolean setLowLatency() throws UnsupportedCommOperationException
 	{
-		log.trace(  "RXTXPort:setLowLatency()");
 		return nativeSetLowLatency();
 	}
 
@@ -2007,7 +1967,6 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 
 	public boolean getLowLatency() throws UnsupportedCommOperationException
 	{
-		log.trace(  "RXTXPort:getLowLatency()");
 		return nativeGetLowLatency();
 	}
 
@@ -2020,7 +1979,6 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public boolean setCallOutHangup(boolean NoHup)
 		throws UnsupportedCommOperationException
 	{
-		log.trace(  "RXTXPort:setCallOutHangup()");
 		return nativeSetCallOutHangup(NoHup);
 	}
 
@@ -2033,7 +1991,6 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public boolean getCallOutHangup()
 		throws UnsupportedCommOperationException
 	{
-		log.trace(  "RXTXPort:getCallOutHangup()");
 		return nativeGetCallOutHangup();
 	}
 
@@ -2046,7 +2003,6 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public boolean clearCommInput()
 		throws UnsupportedCommOperationException
 	{
-		log.trace(  "RXTXPort:clearCommInput()");
 		return nativeClearCommInput();
 	}
 

--- a/src/main/java/gnu/io/RXTXPort.java
+++ b/src/main/java/gnu/io/RXTXPort.java
@@ -63,6 +63,9 @@ import java.util.TooManyListenersException;
 import java.lang.Math;
 import java.util.concurrent.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
 * An extension of gnu.io.SerialPort
 * @see gnu.io.SerialPort
@@ -70,6 +73,8 @@ import java.util.concurrent.*;
 
 public class RXTXPort extends SerialPort
 {
+	private static final Logger log = LoggerFactory.getLogger(RXTXPort.class);
+
 	/* I had a report that some JRE's complain when MonitorThread
 	   tries to access private variables
 	*/
@@ -93,8 +98,7 @@ public class RXTXPort extends SerialPort
 
 		MonitorThread() 
 		{
-			if (debug)
-				z.reportln( "RXTXPort:MontitorThread:MonitorThread()"); 
+			log.trace( "RXTXPort:MonitorThread:MonitorThread()"); 
 		}
 	/**
 	*  run the thread and call the event loop.
@@ -102,13 +106,11 @@ public class RXTXPort extends SerialPort
 		public void run()
 		{
 			try {
-				if (debug)
-					z.reportln( "RXTXPort:MontitorThread:run()"); 
+				log.trace( "RXTXPort:MonitorThread:run()"); 
 				monThreadisInterrupted=false;
 				eventLoop();
 	            eis = 0;
-				if (debug)
-					z.reportln( "eventLoop() returned, this is invalid."); 
+				log.error( "eventLoop() returned, this is invalid."); 
 			}catch(Throwable ex) {
 				HARDWARE_FAULT=true;
 				sendEvent(SerialPortEvent.HARDWARE_ERROR, true);
@@ -116,17 +118,10 @@ public class RXTXPort extends SerialPort
 		}
 		protected void finalize() throws Throwable 
 		{ 
-			if (debug)
-				z.reportln( "RXTXPort:MonitorThread exiting"); 
+			log.trace( "RXTXPort:MonitorThread exiting"); 
 		}
 	}
 	protected boolean HARDWARE_FAULT=false;
-	protected final static boolean debug = false;
-	protected final static boolean debug_read = false;
-	protected final static boolean debug_read_results = false;
-	protected final static boolean debug_write = false;
-	protected final static boolean debug_events = false;
-	protected final static boolean debug_verbose = false;
 
 	private static Zystem z;
 
@@ -136,8 +131,7 @@ public class RXTXPort extends SerialPort
 			z = new Zystem(Zystem.SILENT_MODE);
 		} catch ( Exception e ) {}
 
-		if(debug ) 
-			z.reportln( "RXTXPort {}");
+		log.trace( "RXTXPort {}");
 		//System.loadLibrary( "rxtxSerial" );
 		SerialManager.getInstance();
 	
@@ -156,8 +150,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public RXTXPort( String name ) throws PortInUseException
 	{
-		if (debug)
-			z.reportln( "RXTXPort:RXTXPort("+name+") called");
+		log.trace( "RXTXPort:RXTXPort("+name+") called");
 	/* 
 	   commapi/javadocs/API_users_guide.html specifies that whenever
 	   an application tries to open a port in use by another application
@@ -181,9 +174,7 @@ public class RXTXPort extends SerialPort
 			MonitorThreadAlive=true;
 	//	} catch ( PortInUseException e ){}
 		timeout = -1;	/* default disabled timeout */
-		if (debug)
-			z.reportln( "RXTXPort:RXTXPort("+name+") returns with fd = " +
-				fd);
+		log.trace( "RXTXPort:RXTXPort("+name+") returns with fd = " + fd);
 	}
 	private native synchronized int open( String name )throws PortInUseException;
 
@@ -215,8 +206,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public OutputStream getOutputStream()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:getOutputStream() called and returning");
+		log.trace( "RXTXPort:getOutputStream() called and returning");
 		return out;
 	}
 
@@ -229,8 +219,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public InputStream getInputStream()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:getInputStream() called and returning");
+		log.trace( "RXTXPort:getInputStream() called and returning");
 		return in;
 	}
 
@@ -253,8 +242,7 @@ public class RXTXPort extends SerialPort
 		int p )
 		throws UnsupportedCommOperationException
 	{
-		if (debug)
-			z.reportln( "RXTXPort:setSerialPortParams(" +
+		log.trace( "RXTXPort:setSerialPortParams(" +
 				b + " " + d + " " + s + " " + p + ") called");
 		if ( nativeSetSerialPortParams( b, d, s, p ) )
 			throw new UnsupportedCommOperationException(
@@ -264,7 +252,7 @@ public class RXTXPort extends SerialPort
 		else dataBits = d;
 		stopBits = s;
 		parity = p;
-			z.reportln( "RXTXPort:setSerialPortParams(" +
+		log.trace( "RXTXPort:setSerialPortParams(" +
 				b + " " + d + " " + s + " " + p +
 				") returning");
 	}
@@ -286,8 +274,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public int getBaudRate()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:getBaudRate() called and returning " + speed);
+		log.trace( "RXTXPort:getBaudRate() called and returning " + speed);
 		return speed;
 	}
 
@@ -298,8 +285,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public int getDataBits()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:getDataBits() called and returning " + dataBits);
+		log.trace( "RXTXPort:getDataBits() called and returning " + dataBits);
 		return dataBits;
 	}
 
@@ -310,8 +296,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public int getStopBits()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:getStopBits() called and returning " + stopBits);
+		log.trace( "RXTXPort:getStopBits() called and returning " + stopBits);
 		return stopBits;
 	}
 
@@ -322,8 +307,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public int getParity()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:getParity() called and returning " + parity );
+		log.trace( "RXTXPort:getParity() called and returning " + parity );
 		return parity;
 	}
 
@@ -336,12 +320,10 @@ public class RXTXPort extends SerialPort
 	*/
 	public void setFlowControlMode( int flowcontrol )
 	{
-		if (debug)
-			z.reportln( "RXTXPort:setFlowControlMode( " + flowcontrol + " ) called");
+		log.trace( "RXTXPort:setFlowControlMode( " + flowcontrol + " ) called");
 		if(monThreadisInterrupted) 
 		{
-			if( debug_events )
-				z.reportln(  "RXTXPort:setFlowControlMode MonThread is Interrupeted returning" );
+			log.trace(  "RXTXPort:setFlowControlMode MonThread is Interrupeted returning" );
 			return;
 		}
 		try {
@@ -353,16 +335,14 @@ public class RXTXPort extends SerialPort
 			return;
 		}
 		flowmode=flowcontrol;
-		if (debug)
-			z.reportln( "RXTXPort:setFlowControlMode( " + flowcontrol + " ) returning");
+		log.trace( "RXTXPort:setFlowControlMode( " + flowcontrol + " ) returning");
 	}
 	/** 
 	*  @return  int representing the flowmode
 	*/
 	public int getFlowControlMode()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:getFlowControlMode() returning " + flowmode );
+		log.trace( "RXTXPort:getFlowControlMode() returning " + flowmode );
 		return flowmode;
 	}
 	native void setflowcontrol( int flowcontrol ) throws IOException;
@@ -380,24 +360,21 @@ public class RXTXPort extends SerialPort
 	public void enableReceiveFraming( int f )
 		throws UnsupportedCommOperationException
 	{
-		if (debug)
-			z.reportln( "RXTXPort:enableReceiveFramming() throwing exception");
+		log.trace( "RXTXPort:enableReceiveFramming() throwing exception");
 		throw new UnsupportedCommOperationException( "Not supported" );
 	}
 	/** 
 	*/
 	public void disableReceiveFraming()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:disableReceiveFramming() called and returning (noop)");
+		log.trace( "RXTXPort:disableReceiveFramming() called and returning (noop)");
 	}
 	/** 
 	*  @return true if framing is enabled
 	*/
 	public boolean isReceiveFramingEnabled()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:isReceiveFrammingEnabled() called and returning " + false );
+		log.trace( "RXTXPort:isReceiveFrammingEnabled() called and returning " + false );
 		return false;
 	}
 	/** 
@@ -405,8 +382,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public int getReceiveFramingByte()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:getReceiveFrammingByte() called and returning " + 0 );
+		log.trace( "RXTXPort:getReceiveFrammingByte() called and returning " + 0 );
 		return 0;
 	}
 
@@ -433,21 +409,18 @@ public class RXTXPort extends SerialPort
 	*/
 	public void disableReceiveTimeout()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:disableReceiveTimeout() called");
+		log.trace( "RXTXPort:disableReceiveTimeout() called");
 		timeout = -1;
 		NativeEnableReceiveTimeoutThreshold( timeout , threshold, InputBuffer );
-		if (debug)
-			z.reportln( "RXTXPort:disableReceiveTimeout() returning");
+		log.trace( "RXTXPort:disableReceiveTimeout() returning");
 	}
 	/** 
 	*  @param time
 	*/
 	public void enableReceiveTimeout( int time )
 	{
-		//System.out.println("Enabling receive timeout: "+time);
-		if (debug)
-			z.reportln( "RXTXPort:enableReceiveTimeout() called");
+		//log.trace("Enabling receive timeout: "+time);
+		log.trace( "RXTXPort:enableReceiveTimeout() called");
 		if( time >= 0 )
 		{
 			timeout = time;
@@ -461,16 +434,14 @@ public class RXTXPort extends SerialPort
 				"Unexpected negative timeout value"
 			);
 		}
-		if (debug)
-			z.reportln( "RXTXPort:enableReceiveTimeout() returning");
+		log.trace( "RXTXPort:enableReceiveTimeout() returning");
 	}
 	/** 
 	*  @return  boolean true if recieve timeout is enabled
 	*/
 	public boolean isReceiveTimeoutEnabled()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:isReceiveTimeoutEnabled() called and returning " + NativeisReceiveTimeoutEnabled() );
+		log.trace( "RXTXPort:isReceiveTimeoutEnabled() called and returning " + NativeisReceiveTimeoutEnabled() );
 		return( NativeisReceiveTimeoutEnabled() );
 	}
 	/** 
@@ -478,8 +449,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public int getReceiveTimeout()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:getReceiveTimeout() called and returning " + NativegetReceiveTimeout() );
+		log.trace( "RXTXPort:getReceiveTimeout() called and returning " + NativegetReceiveTimeout() );
 		return(NativegetReceiveTimeout( ));
 	}
 
@@ -492,8 +462,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public void enableReceiveThreshold( int thresh )
 	{
-		if (debug)
-			z.reportln( "RXTXPort:enableReceiveThreshold( " + thresh + " ) called");
+		log.trace( "RXTXPort:enableReceiveThreshold( " + thresh + " ) called");
 		if(thresh >=0)
 		{
 			threshold=thresh;
@@ -507,15 +476,13 @@ public class RXTXPort extends SerialPort
 				"Unexpected negative threshold value"
 			);
 		}
-		if (debug)
-			z.reportln( "RXTXPort:enableReceiveThreshold( " + thresh + " ) returned");
+		log.trace( "RXTXPort:enableReceiveThreshold( " + thresh + " ) returned");
 	}
 	/** 
 	*/
 	public void disableReceiveThreshold()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:disableReceiveThreshold() called and returning");
+		log.trace( "RXTXPort:disableReceiveThreshold() called and returning");
 		enableReceiveThreshold(0);
 	}
 	/** 
@@ -523,8 +490,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public int getReceiveThreshold()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:getReceiveThreshold() called and returning " + threshold);
+		log.trace( "RXTXPort:getReceiveThreshold() called and returning " + threshold);
 		return threshold;
 	}
 	/** 
@@ -532,8 +498,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public boolean isReceiveThresholdEnabled()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:isReceiveThresholdEnable() called and returning" + (threshold > 0) );
+		log.trace( "RXTXPort:isReceiveThresholdEnable() called and returning" + (threshold > 0) );
 		return(threshold>0);
 	}
 
@@ -551,25 +516,20 @@ public class RXTXPort extends SerialPort
 	*/
 	public void setInputBufferSize( int size )
 	{
-		if (debug)
-			z.reportln( "RXTXPort:setInputBufferSize( " +
-					size + ") called");
+		log.trace( "RXTXPort:setInputBufferSize( " + size + ") called");
 		if( size < 0 )
 			throw new IllegalArgumentException
 			(
 				"Unexpected negative buffer size value"
 			);
 		else InputBuffer=size;
-		if (debug)
-			z.reportln( "RXTXPort:setInputBufferSize( " +
-					size + ") returning");
+		log.trace( "RXTXPort:setInputBufferSize( " + size + ") returning");
 	}
 	/** 
 	*/
 	public int getInputBufferSize()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:getInputBufferSize() called and returning " + InputBuffer );
+		log.trace( "RXTXPort:getInputBufferSize() called and returning " + InputBuffer );
 		return(InputBuffer);
 	}
 	/** 
@@ -577,18 +537,14 @@ public class RXTXPort extends SerialPort
 	*/
 	public void setOutputBufferSize( int size )
 	{
-		if (debug)
-			z.reportln( "RXTXPort:setOutputBufferSize( " +
-					size + ") called");
+		log.trace( "RXTXPort:setOutputBufferSize( " + size + ") called");
 		if( size < 0 )
 			throw new IllegalArgumentException
 			(
 				"Unexpected negative buffer size value"
 			);
 		else OutputBuffer=size;
-		if (debug)
-			z.reportln( "RXTXPort:setOutputBufferSize( " +
-					size + ") returned");
+		log.trace( "RXTXPort:setOutputBufferSize( " + size + ") returned");
 		
 	}
 	/** 
@@ -596,8 +552,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public int getOutputBufferSize()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:getOutputBufferSize() called and returning " + OutputBuffer );
+		log.trace( "RXTXPort:getOutputBufferSize() called and returning " + OutputBuffer );
 		return(OutputBuffer);
 	}
 
@@ -676,18 +631,13 @@ public class RXTXPort extends SerialPort
 	private native void interruptEventLoop( );
 	public boolean checkMonitorThread()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:checkMonitorThread()");
+		log.trace( "RXTXPort:checkMonitorThread()");
 		if(monThread != null)
 		{
-			if ( debug )
-				z.reportln( 
-					"monThreadisInterrupted = " +
-					monThreadisInterrupted );
+			log.trace( "monThreadisInterrupted = " + monThreadisInterrupted );
 			return monThreadisInterrupted;
 		}
-		if ( debug )
-			z.reportln(  "monThread is null " );
+		log.trace(  "monThread is null " );
 		return(true);
 	}
 
@@ -698,8 +648,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public boolean sendEvent( int event, boolean state )
 	{
-		if (debug_events)
-			z.report( "RXTXPort:sendEvent(");
+		log.trace( "RXTXPort:sendEvent(");
 		/* Let the native side know its time to die */
 
 		if ( fd == 0 || SPEventListener == null || monThread == null)
@@ -710,70 +659,43 @@ public class RXTXPort extends SerialPort
 		switch( event )
 		{
 			case SerialPortEvent.HARDWARE_ERROR:
-			if( debug_events )
-				z.reportln( "HARDWARE_ERROR " +
+			log.debug( "HARDWARE_ERROR " +
 					monThread.Data + ")" );
 			break;case SerialPortEvent.DATA_AVAILABLE:
-				if( debug_events )
-					z.reportln( "DATA_AVAILABLE " +
-						monThread.Data + ")" );
+				log.debug( "DATA_AVAILABLE " + monThread.Data + ")" );
 				break;
 			case SerialPortEvent.OUTPUT_BUFFER_EMPTY:
-				if( debug_events )
-					z.reportln( 
-						"OUTPUT_BUFFER_EMPTY " +
-						monThread.Output + ")" );
+				log.debug( "OUTPUT_BUFFER_EMPTY " + monThread.Output + ")" );
 				break;
 			case SerialPortEvent.CTS:
-				if( debug_events )
-					z.reportln( "CTS " +
-						monThread.CTS + ")" );
+				log.debug( "CTS " + monThread.CTS + ")" );
 				break;
 			case SerialPortEvent.DSR:
-				if( debug_events )
-					z.reportln( "DSR " +
-						monThread.Output + ")" );
+				log.debug( "DSR " + monThread.Output + ")" );
 				break;
 			case SerialPortEvent.RI:
-				if( debug_events )
-					z.reportln( "RI " +
-						monThread.RI + ")" );
+				log.debug( "RI " + monThread.RI + ")" );
 				break;
 			case SerialPortEvent.CD:
-				if( debug_events )
-					z.reportln( "CD " +
-						monThread.CD + ")" );
+				log.debug( "CD " + monThread.CD + ")" );
 				break;
 			case SerialPortEvent.OE:
-				if( debug_events )
-					z.reportln( "OE " +
-						monThread.OE + ")" );
+				log.debug( "OE " + monThread.OE + ")" );
 				break;
 			case SerialPortEvent.PE:
-				if( debug_events )
-					z.reportln( "PE " +
-						monThread.PE + ")" );
+				log.debug( "PE " + monThread.PE + ")" );
 				break;
 			case SerialPortEvent.FE:
-				if( debug_events )
-					z.reportln( "FE " +
-						monThread.FE + ")" );
+				log.debug( "FE " + monThread.FE + ")" );
 				break;
 			case SerialPortEvent.BI:
-				if( debug_events )
-					z.reportln( "BI " +
-						monThread.BI + ")" );
+				log.debug( "BI " + monThread.BI + ")" );
 				break;
 			default:
-				if( debug_events )
-					z.reportln( "XXXXXXXXXXXXXX " +
-						event + ")" );
+				log.debug( "XXXXXXXXXXXXXX " + event + ")" );
 				break;
 		}
-		if( debug_events ) {
-			if (debug_verbose)
-				z.reportln(  "	checking flags " );
-		}
+		log.trace(  "	checking flags " );
 
 		switch( event )
 		{
@@ -810,23 +732,16 @@ public class RXTXPort extends SerialPort
 			case SerialPortEvent.HARDWARE_ERROR:
 				break;
 			default:
-				System.err.println( "unknown event: " + event);
+				log.debug( "unknown event: " + event);
 				return(false);
 		}
-		if( debug_events ) {
-			if (debug_verbose)
-				z.reportln(  "	getting event" );
-		}
+		log.trace(  "	getting event" );
 		SerialPortEvent e = new SerialPortEvent(this, event, !state,
 			state );
-		if( debug_events ) {
-			if (debug_verbose)
-				z.reportln(  "	sending event" );
-		}
+		log.trace(  "	sending event" );
 		if(monThreadisInterrupted) 
 		{
-			if( debug_events )
-				z.reportln(  "	sendEvent return" );
+			log.trace(  "	sendEvent return" );
 			return(true);
 		}
 		if( SPEventListener != null )
@@ -834,10 +749,7 @@ public class RXTXPort extends SerialPort
 			SPEventListener.serialEvent( e );
 		}
 
-		if( debug_events ) {
-			if (debug_verbose)
-				z.reportln(  "	sendEvent return" );
-		}
+		log.trace(  "	sendEvent return" );
 
 		if (fd == 0 ||  SPEventListener == null || monThread == null) 
 		{
@@ -864,8 +776,7 @@ public class RXTXPort extends SerialPort
 		    Eventloop is ready
 		*/
 
-		if (debug)
-			z.reportln( "RXTXPort:addEventListener()");
+		log.trace( "RXTXPort:addEventListener()");
 		if( SPEventListener != null )
 		{
 			throw new TooManyListenersException();
@@ -880,41 +791,36 @@ public class RXTXPort extends SerialPort
 			waitForTheNativeCodeSilly();
 			MonitorThreadAlive=true;
 		}
-		if (debug)
-			z.reportln( "RXTXPort:Interrupt=false");
+		log.trace( "RXTXPort:Interrupt=false");
 	}
 	/**
 	*  Remove the serial port event listener
 	*/
 	public void removeEventListener()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:removeEventListener() called");
+		log.trace( "RXTXPort:removeEventListener() called");
 		waitForTheNativeCodeSilly();
 		//if( monThread != null && monThread.isAlive() )
 		if( monThreadisInterrupted == true )
 		{
-			z.reportln( "	RXTXPort:removeEventListener() already interrupted");
+			log.debug( "	RXTXPort:removeEventListener() already interrupted");
 			monThread = null;
 			SPEventListener = null;
 			return;
 		}
 		else if( monThread != null && monThread.isAlive() && !HARDWARE_FAULT)                       
 		{
-			if (debug)
-				z.reportln( "	RXTXPort:Interrupt=true");
+			log.trace( "	RXTXPort:Interrupt=true");
 			monThreadisInterrupted=true;
 			/*
 			   Notify all threads in this PID that something is up
 			   They will call back to see if its their thread
 			   using isInterrupted().
 			*/
-			if (debug)
-				z.reportln( "	RXTXPort:calling interruptEventLoop");
+			log.trace( "	RXTXPort:calling interruptEventLoop");
 			interruptEventLoop( );
 			
-			if (debug)
-				z.reportln( "	RXTXPort:calling monThread.join()");
+			log.trace( "	RXTXPort:calling monThread.join()");
 			try {
 
 				// wait a reasonable moment for the death of the monitor thread
@@ -926,11 +832,8 @@ public class RXTXPort extends SerialPort
 				return;
  			}
 				
-			if ( debug ) {
-				if (monThread.isAlive()) {
-					z.reportln( "	MonThread is still alive!");
-
-				}
+			if (monThread.isAlive()) {
+				log.debug( "	MonThread is still alive!");
 			}
 			
 		}
@@ -939,7 +842,7 @@ public class RXTXPort extends SerialPort
 		MonitorThreadLock = false;
 		MonitorThreadAlive=false;
 		monThreadisInterrupted=true;
-		z.reportln( "RXTXPort:removeEventListener() returning");
+		log.trace( "RXTXPort:removeEventListener() returning");
 	}
 	/**
 	 *	Give the native code a chance to start listening to the hardware
@@ -966,9 +869,7 @@ public class RXTXPort extends SerialPort
 						boolean flag );
 	public void notifyOnDataAvailable( boolean enable )
 	{
-		if (debug)
-			z.reportln( "RXTXPort:notifyOnDataAvailable( " +
-				enable+" )");
+		log.trace( "RXTXPort:notifyOnDataAvailable( " + enable+" )");
 		
 		waitForTheNativeCodeSilly();
 
@@ -984,9 +885,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public void notifyOnOutputEmpty( boolean enable )
 	{
-		if (debug)
-			z.reportln( "RXTXPort:notifyOnOutputEmpty( " +
-				enable+" )");
+		log.trace( "RXTXPort:notifyOnOutputEmpty( " + enable+" )");
 		waitForTheNativeCodeSilly();
 		MonitorThreadLock = true;
 		nativeSetEventFlag( fd, SerialPortEvent.OUTPUT_BUFFER_EMPTY,
@@ -1000,9 +899,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public void notifyOnCTS( boolean enable )
 	{
-		if (debug)
-			z.reportln( "RXTXPort:notifyOnCTS( " +
-				enable+" )");
+		log.trace( "RXTXPort:notifyOnCTS( " + enable+" )");
 		waitForTheNativeCodeSilly();
 		MonitorThreadLock = true;
 		nativeSetEventFlag( fd, SerialPortEvent.CTS, enable );
@@ -1014,9 +911,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public void notifyOnDSR( boolean enable )
 	{
-		if (debug)
-			z.reportln( "RXTXPort:notifyOnDSR( " +
-				enable+" )");
+		log.trace( "RXTXPort:notifyOnDSR( " + enable+" )");
 		waitForTheNativeCodeSilly();
 		MonitorThreadLock = true;
 		nativeSetEventFlag( fd, SerialPortEvent.DSR, enable );
@@ -1028,9 +923,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public void notifyOnRingIndicator( boolean enable )
 	{
-		if (debug)
-			z.reportln( "RXTXPort:notifyOnRingIndicator( " +
-				enable+" )");
+		log.trace( "RXTXPort:notifyOnRingIndicator( " + enable+" )");
 		waitForTheNativeCodeSilly();
 		MonitorThreadLock = true;
 		nativeSetEventFlag( fd, SerialPortEvent.RI, enable );
@@ -1042,9 +935,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public void notifyOnCarrierDetect( boolean enable )
 	{
-		if (debug)
-			z.reportln( "RXTXPort:notifyOnCarrierDetect( " +
-				enable+" )");
+		log.trace( "RXTXPort:notifyOnCarrierDetect( " + enable+" )");
 		waitForTheNativeCodeSilly();
 		MonitorThreadLock = true;
 		nativeSetEventFlag( fd, SerialPortEvent.CD, enable );
@@ -1056,9 +947,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public void notifyOnOverrunError( boolean enable )
 	{
-		if (debug)
-			z.reportln( "RXTXPort:notifyOnOverrunError( " +
-				enable+" )");
+		log.trace( "RXTXPort:notifyOnOverrunError( " + enable+" )");
 		waitForTheNativeCodeSilly();
 		MonitorThreadLock = true;
 		nativeSetEventFlag( fd, SerialPortEvent.OE, enable );
@@ -1070,9 +959,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public void notifyOnParityError( boolean enable )
 	{
-		if (debug)
-			z.reportln( "RXTXPort:notifyOnParityError( " +
-				enable+" )");
+		log.trace( "RXTXPort:notifyOnParityError( " + enable+" )");
 		waitForTheNativeCodeSilly();
 		MonitorThreadLock = true;
 		nativeSetEventFlag( fd, SerialPortEvent.PE, enable );
@@ -1084,9 +971,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public void notifyOnFramingError( boolean enable )
 	{
-		if (debug)
-			z.reportln( "RXTXPort:notifyOnFramingError( " +
-				enable+" )");
+		log.trace( "RXTXPort:notifyOnFramingError( " + enable+" )");
 		waitForTheNativeCodeSilly();
 		MonitorThreadLock = true;
 		nativeSetEventFlag( fd, SerialPortEvent.FE, enable );
@@ -1098,9 +983,7 @@ public class RXTXPort extends SerialPort
 	*/
 	public void notifyOnBreakInterrupt( boolean enable )
 	{
-		if (debug)
-			z.reportln( "RXTXPort:notifyOnBreakInterrupt( " +
-				enable+" )");
+		log.trace( "RXTXPort:notifyOnBreakInterrupt( " + enable+" )");
 		waitForTheNativeCodeSilly();
 		MonitorThreadLock = true;
 		nativeSetEventFlag( fd, SerialPortEvent.BI, enable );
@@ -1113,39 +996,33 @@ public class RXTXPort extends SerialPort
 
     public void close()
 	{
-                if (debug)
-                        z.reportln( "RXTXPort:close( " + this.name + " )"); 
+                log.trace( "RXTXPort:close( " + this.name + " )"); 
 
                 try {
                         while( !IOLockedMutex.writeLock().tryLock(500, TimeUnit.MILLISECONDS) )
                         {
-                                if( debug )
-                                        z.reportln("IO is locked " + IOLockedMutex.getReadLockCount());
+                                log.debug("IO is locked " + IOLockedMutex.getReadLockCount());
                         }
  
                         if ( fd <= 0 )
                         {
-                                z.reportln(  "RXTXPort:close detected bad File Descriptor" );
+                                log.debug(  "RXTXPort:close detected bad File Descriptor" );
                                 return;
                         }
                         disableRs485();
                         if(!HARDWARE_FAULT) setDTR(false);
                         if(!HARDWARE_FAULT) setDSR(false);
-                        if (debug)
-                                z.reportln( "RXTXPort:close( " + this.name + " ) setting monThreadisInterrupted"); 
+                        log.trace( "RXTXPort:close( " + this.name + " ) setting monThreadisInterrupted"); 
                         if ( ! monThreadisInterrupted )
                         {
                                 removeEventListener();
                         }
-                        if (debug)
-                                z.reportln( "RXTXPort:close( " + this.name + " ) calling nativeClose"); 
+                        log.trace( "RXTXPort:close( " + this.name + " ) calling nativeClose"); 
                         nativeClose( this.name );
-                        if (debug)
-                                z.reportln( "RXTXPort:close( " + this.name + " ) calling super.close"); 
+                        log.trace( "RXTXPort:close( " + this.name + " ) calling super.close"); 
                         super.close();
                         fd = 0;
-                        if (debug)
-                                z.reportln( "RXTXPort:close( " + this.name + " ) leaving"); 
+                        log.trace( "RXTXPort:close( " + this.name + " ) leaving"); 
                 } catch( InterruptedException ie ) {
                         // somebody called interrupt() on us
                         // we obey and return without closing the socket
@@ -1165,12 +1042,10 @@ public class RXTXPort extends SerialPort
 	/** Finalize the port */
 	protected void finalize()
 	{
-		if (debug)
-			z.reportln( "RXTXPort:finalize()");
+		log.trace( "RXTXPort:finalize()");
 		if( fd > 0 )
 		{
-			if (debug)
-				z.reportln( "RXTXPort:calling close()");
+			log.trace( "RXTXPort:calling close()");
 			close();
 		}
 		z.finalize();
@@ -1185,8 +1060,7 @@ public class RXTXPort extends SerialPort
 	*/
 		public void write( int b ) throws IOException
 		{
-			if (debug_write)
-				z.reportln( "RXTXPort:SerialOutputStream:write(int)");
+			log.trace( "RXTXPort:SerialOutputStream:write(int)");
 			if( speed == 0 ) return;
 			if ( monThreadisInterrupted == true )
 			{
@@ -1197,12 +1071,11 @@ public class RXTXPort extends SerialPort
 				waitForTheNativeCodeSilly();
 				if ( fd == 0 )
 				{
-					System.err.println("File Descriptor for prot zero!!");
+					log.error("File Descriptor for prot zero!!");
 					throw new IOException();
 				}
 				writeByte( b, monThreadisInterrupted );
-				if (debug_write)
-					z.reportln( "Leaving RXTXPort:SerialOutputStream:write( int )");
+				log.trace( "Leaving RXTXPort:SerialOutputStream:write( int )");
 			} finally {
 				IOLockedMutex.readLock().unlock();
 			}
@@ -1213,10 +1086,7 @@ public class RXTXPort extends SerialPort
 	*/
 		public void write( byte b[] ) throws IOException
 		{
-			if (debug_write)
-			{
-				z.reportln( "Entering RXTXPort:SerialOutputStream:write(" + b.length + ") "/* + new String(b)*/ );
-			}
+			log.trace( "Entering RXTXPort:SerialOutputStream:write(" + b.length + ") "/* + new String(b)*/ );
 			if( speed == 0 ) return;
 			if ( monThreadisInterrupted == true )
 			{
@@ -1227,8 +1097,7 @@ public class RXTXPort extends SerialPort
 			try {
 				waitForTheNativeCodeSilly();
 				writeArray( b, 0, b.length, monThreadisInterrupted );
-				if (debug_write)
-					z.reportln( "Leaving RXTXPort:SerialOutputStream:write(" +b.length  +")");
+				log.trace( "Leaving RXTXPort:SerialOutputStream:write(" +b.length  +")");
 			} finally {
 				IOLockedMutex.readLock().unlock();
 			}
@@ -1253,10 +1122,7 @@ public class RXTXPort extends SerialPort
 	 
 			byte send[] = new byte[len];
 			System.arraycopy( b, off, send, 0, len );
-			if (debug_write)
-			{
-				z.reportln( "Entering RXTXPort:SerialOutputStream:write(" + send.length + " " + off + " " + len + " " +") " /*+  new String(send) */ );
-			}
+			log.trace( "Entering RXTXPort:SerialOutputStream:write(" + send.length + " " + off + " " + len + " " +") " /*+  new String(send) */ );
 			if ( fd == 0 ) throw new IOException();
 			if ( monThreadisInterrupted == true )
 			{
@@ -1267,8 +1133,7 @@ public class RXTXPort extends SerialPort
 			{
 				waitForTheNativeCodeSilly();
 				writeArray( send, 0, len, monThreadisInterrupted );
-				if( debug_write )
-					z.reportln( "Leaving RXTXPort:SerialOutputStream:write(" + send.length + " " + off + " " + len + " " +") "  /*+ new String(send)*/ );
+				log.trace( "Leaving RXTXPort:SerialOutputStream:write(" + send.length + " " + off + " " + len + " " +") "  /*+ new String(send)*/ );
 			} finally {
 				IOLockedMutex.readLock().unlock();
 			}
@@ -1277,14 +1142,12 @@ public class RXTXPort extends SerialPort
 	*/
 		public void flush() throws IOException
 		{
-			if (debug)
-				z.reportln( "RXTXPort:SerialOutputStream:flush() enter");
+			log.trace( "RXTXPort:SerialOutputStream:flush() enter");
 			if( speed == 0 ) return;
 			if ( fd == 0 ) throw new IOException();
 			if ( monThreadisInterrupted == true )
 			{
-			if (debug)
-				z.reportln( "RXTXPort:SerialOutputStream:flush() Leaving Interrupted");
+				log.trace( "RXTXPort:SerialOutputStream:flush() Leaving Interrupted");
 				return;
 			}
 			IOLockedMutex.readLock().lock();
@@ -1297,8 +1160,7 @@ public class RXTXPort extends SerialPort
 				*/
 				if ( nativeDrain( monThreadisInterrupted ) )
 					sendEvent( SerialPortEvent.OUTPUT_BUFFER_EMPTY, true );
-				if (debug)
-					z.reportln( "RXTXPort:SerialOutputStream:flush() leave");
+				log.trace( "RXTXPort:SerialOutputStream:flush() leave");
 			}
 			finally
 			{
@@ -1327,24 +1189,20 @@ public class RXTXPort extends SerialPort
 	*/
 		public synchronized int read() throws IOException
 		{
-			if (debug_read)
-				z.reportln( "RXTXPort:SerialInputStream:read() called");
+			log.trace( "RXTXPort:SerialInputStream:read() called");
 			if ( fd == 0 ) throw new IOException();
 			if ( monThreadisInterrupted )
 			{
-				z.reportln( "+++++++++ read() monThreadisInterrupted" );
+				log.debug( "+++++++++ read() monThreadisInterrupted" );
 			}
 			IOLockedMutex.readLock().lock();
 			try {
-				if (debug_read_results)
-					z.reportln(  "RXTXPort:SerialInputStream:read() L" );
+				log.trace(  "RXTXPort:SerialInputStream:read() L" );
 				waitForTheNativeCodeSilly();
-				if (debug_read_results)
-					z.reportln(  "RXTXPort:SerialInputStream:read() N" );
+				log.trace(  "RXTXPort:SerialInputStream:read() N" );
 				int result = readByte();
-				if (debug_read_results)
-					//z.reportln(  "RXTXPort:SerialInputStream:read() returns byte = " + result );
-					z.reportln(  "RXTXPort:SerialInputStream:read() returns" );
+				//log.trace(  "RXTXPort:SerialInputStream:read() returns byte = " + result );
+				log.trace(  "RXTXPort:SerialInputStream:read() returns" );
 				return( result );
 			}				
 			finally
@@ -1368,8 +1226,7 @@ public class RXTXPort extends SerialPort
 		public synchronized int read( byte b[] ) throws IOException
 		{
 			int result;
-			if (debug_read)
-				z.reportln( "RXTXPort:SerialInputStream:read(" + b.length + ") called");
+			log.trace( "RXTXPort:SerialInputStream:read(" + b.length + ") called");
 			if ( monThreadisInterrupted == true )
 			{
 				return(0);
@@ -1379,8 +1236,7 @@ public class RXTXPort extends SerialPort
 			{
 				waitForTheNativeCodeSilly();
 				result = read( b, 0, b.length);
-				if (debug_read_results)
-					z.reportln(  "RXTXPort:SerialInputStream:read() returned " + result + " bytes" );
+				log.trace(  "RXTXPort:SerialInputStream:read() returned " + result + " bytes" );
 				return( result );
 			}
 			finally
@@ -1411,33 +1267,29 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 		public synchronized int read( byte b[], int off, int len )
 			throws IOException
 		{
-			if (debug_read)
-				z.reportln( "RXTXPort:SerialInputStream:read(" + b.length + " " + off + " " + len + ") called" /*+ new String(b) */ );
+			log.trace( "RXTXPort:SerialInputStream:read(" + b.length + " " + off + " " + len + ") called" /*+ new String(b) */ );
 			int result;
 			/*
 			 * Some sanity checks
 			 */
 			if ( fd == 0 )
 			{
-				if (debug_read)
-					z.reportln( "RXTXPort:SerialInputStream:read() fd == 0");
-				z.reportln("+++++++ IOException()\n");
+				log.trace( "RXTXPort:SerialInputStream:read() fd == 0");
+				log.debug("+++++++ IOException()\n");
 				throw new IOException();
 			}
 
 			if( b==null )
 			{
-				z.reportln("+++++++ NullPointerException()\n");
-				if (debug_read)
-					z.reportln( "RXTXPort:SerialInputStream:read() b == 0");
+				log.debug("+++++++ NullPointerException()\n");
+				log.trace( "RXTXPort:SerialInputStream:read() b == 0");
 				throw new NullPointerException();
 			}
 
 			if( (off < 0) || (len < 0) || (off+len > b.length))
 			{
-				z.reportln("+++++++ IndexOutOfBoundsException()\n");
-				if (debug_read)
-					z.reportln( "RXTXPort:SerialInputStream:read() off < 0 ..");
+				log.debug("+++++++ IndexOutOfBoundsException()\n");
+				log.trace( "RXTXPort:SerialInputStream:read() off < 0 ..");
 				throw new IndexOutOfBoundsException();
 			}
 
@@ -1446,8 +1298,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 			 */
 			if( len==0 )
 			{
-				if (debug_read)
-					z.reportln( "RXTXPort:SerialInputStream:read() off < 0 ..");
+				log.trace( "RXTXPort:SerialInputStream:read() len == 0");
 				return 0;
 			}
 			/*
@@ -1481,8 +1332,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 			}
 			if ( monThreadisInterrupted == true )
 			{
-				if (debug_read)
-					z.reportln( "RXTXPort:SerialInputStream:read() Interrupted");
+				log.debug( "RXTXPort:SerialInputStream:read() Interrupted");
 				return(0);
 			}
 			IOLockedMutex.readLock().lock();
@@ -1490,8 +1340,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 			{
 				waitForTheNativeCodeSilly();
 				result = readArray( b, off, Minimum);
-				if (debug_read_results)
-					z.reportln( "RXTXPort:SerialInputStream:read(" + b.length + " " + off + " " + len + ") returned " + result + " bytes"  /*+ new String(b) */);
+				log.trace( "RXTXPort:SerialInputStream:read(" + b.length + " " + off + " " + len + ") returned " + result + " bytes"  /*+ new String(b) */);
 				return( result );
 			}
 			finally
@@ -1520,33 +1369,29 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 		public synchronized int read( byte b[], int off, int len, byte t[] )
 			throws IOException
 		{
-			if (debug_read)
-				z.reportln( "RXTXPort:SerialInputStream:read(" + b.length + " " + off + " " + len + ") called" /*+ new String(b) */ );
+			log.trace( "RXTXPort:SerialInputStream:read(" + b.length + " " + off + " " + len + ") called" /*+ new String(b) */ );
 			int result;
 			/*
 			 * Some sanity checks
 			 */
 			if ( fd == 0 )
 			{
-				if (debug_read)
-					z.reportln( "RXTXPort:SerialInputStream:read() fd == 0");
-				z.reportln("+++++++ IOException()\n");
+				log.trace( "RXTXPort:SerialInputStream:read() fd == 0");
+				log.debug("+++++++ IOException()\n");
 				throw new IOException();
 			}
 
 			if( b==null )
 			{
-				z.reportln("+++++++ NullPointerException()\n");
-				if (debug_read)
-					z.reportln( "RXTXPort:SerialInputStream:read() b == 0");
+				log.debug("+++++++ NullPointerException()\n");
+				log.trace( "RXTXPort:SerialInputStream:read() b == 0");
 				throw new NullPointerException();
 			}
 
 			if( (off < 0) || (len < 0) || (off+len > b.length))
 			{
-				z.reportln("+++++++ IndexOutOfBoundsException()\n");
-				if (debug_read)
-					z.reportln( "RXTXPort:SerialInputStream:read() off < 0 ..");
+				log.debug("+++++++ IndexOutOfBoundsException()\n");
+				log.trace( "RXTXPort:SerialInputStream:read() off < 0 ..");
 				throw new IndexOutOfBoundsException();
 			}
 
@@ -1555,8 +1400,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 			 */
 			if( len==0 )
 			{
-				if (debug_read)
-					z.reportln( "RXTXPort:SerialInputStream:read() off < 0 ..");
+				log.trace( "RXTXPort:SerialInputStream:read() len == 0");
 				return 0;
 			}
 			/*
@@ -1590,8 +1434,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 			}
 			if ( monThreadisInterrupted == true )
 			{
-				if (debug_read)
-					z.reportln( "RXTXPort:SerialInputStream:read() Interrupted");
+				log.debug( "RXTXPort:SerialInputStream:read() Interrupted");
 				return(0);
 			}
 			IOLockedMutex.readLock().lock();
@@ -1599,8 +1442,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 			{
 				waitForTheNativeCodeSilly();
 				result = readTerminatedArray( b, off, Minimum, t );
-				if (debug_read_results)
-					z.reportln( "RXTXPort:SerialInputStream:read(" + b.length + " " + off + " " + len + ") returned " + result + " bytes"  /*+ new String(b) */);
+				log.trace( "RXTXPort:SerialInputStream:read(" + b.length + " " + off + " " + len + ") returned " + result + " bytes"  /*+ new String(b) */);
 				return( result );
 			}
 			finally
@@ -1618,15 +1460,12 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 			{
 				return(0);
 			}
-			if ( debug_verbose )
-				z.reportln( "RXTXPort:available() called" );
+			log.trace( "RXTXPort:available() called" );
 			IOLockedMutex.readLock().lock();
 			try
 			{
 				int r = nativeavailable();
-				if ( debug_verbose )
-					z.reportln( "RXTXPort:available() returning " +
-						r );
+				log.trace( "RXTXPort:available() returning " + r );
 				return r;
 			}
 			finally
@@ -1727,9 +1566,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public static int staticGetBaudRate( String port )
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln( 
-				"RXTXPort:staticGetBaudRate( " + port + " )");
+		log.trace("RXTXPort:staticGetBaudRate( " + port + " )");
 		return(nativeStaticGetBaudRate( port ));
 	}
 	/**
@@ -1745,9 +1582,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public static int staticGetDataBits( String port )
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln( 
-				"RXTXPort:staticGetDataBits( " + port + " )");
+		log.trace("RXTXPort:staticGetDataBits( " + port + " )");
 		return(nativeStaticGetDataBits( port ) );
 	}
 
@@ -1764,9 +1599,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public static int staticGetParity( String port )
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln( 
-				"RXTXPort:staticGetParity( " + port + " )");
+		log.trace("RXTXPort:staticGetParity( " + port + " )");
 		return( nativeStaticGetParity( port ) );
 	}
 
@@ -1783,10 +1616,8 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public static int staticGetStopBits( String port )
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln( 
-				"RXTXPort:staticGetStopBits( " + port + " )");
-			return(nativeStaticGetStopBits( port ) );
+		log.trace("RXTXPort:staticGetStopBits( " + port + " )");
+		return(nativeStaticGetStopBits( port ) );
 	}
 
 	/** 
@@ -1810,10 +1641,8 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 		int s, int p )
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln( 
-				"RXTXPort:staticSetSerialPortParams( " +
-				f + " " + b + " " + d + " " + s + " " + p );
+		log.trace("RXTXPort:staticSetSerialPortParams( " +
+			f + " " + b + " " + d + " " + s + " " + p );
 		nativeStaticSetSerialPortParams( f, b, d, s, p );
 	}
 
@@ -1834,9 +1663,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public static boolean staticSetDSR( String port, boolean flag )
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln(  "RXTXPort:staticSetDSR( " + port +
-						" " + flag );
+		log.trace(  "RXTXPort:staticSetDSR( " + port + " " + flag );
 		return( nativeStaticSetDSR( port, flag ) );
 	}
 
@@ -1857,9 +1684,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public static boolean staticSetDTR( String port, boolean flag )
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln(  "RXTXPort:staticSetDTR( " + port +
-						" " + flag );
+		log.trace(  "RXTXPort:staticSetDTR( " + port + " " + flag );
 		return( nativeStaticSetDTR( port, flag ) );
 	}
 
@@ -1880,9 +1705,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public static boolean staticSetRTS( String port, boolean flag )
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln(  "RXTXPort:staticSetRTS( " + port +
-						" " + flag );
+		log.trace(  "RXTXPort:staticSetRTS( " + port + " " + flag );
 		return( nativeStaticSetRTS( port, flag ) );
 	}
 
@@ -1902,8 +1725,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public static boolean staticIsRTS( String port )
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln(  "RXTXPort:staticIsRTS( " + port + " )" );
+		log.trace(  "RXTXPort:staticIsRTS( " + port + " )" );
 		return( nativeStaticIsRTS( port ) );
 	}
 	/**
@@ -1922,8 +1744,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public static boolean staticIsCD( String port )
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln( "RXTXPort:staticIsCD( " + port + " )" );
+		log.trace( "RXTXPort:staticIsCD( " + port + " )" );
 		return( nativeStaticIsCD( port ) );
 	}
 	/**
@@ -1942,8 +1763,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public static boolean staticIsCTS( String port )
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln(  "RXTXPort:staticIsCTS( " + port + " )" );
+		log.trace(  "RXTXPort:staticIsCTS( " + port + " )" );
 		return( nativeStaticIsCTS( port ) );
 	}
 	/**
@@ -1962,8 +1782,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public static boolean staticIsDSR( String port )
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln(  "RXTXPort:staticIsDSR( " + port + " )" );
+		log.trace(  "RXTXPort:staticIsDSR( " + port + " )" );
 		return( nativeStaticIsDSR( port ) );
 	}
 	/**
@@ -1982,8 +1801,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public static boolean staticIsDTR( String port )
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln(  "RXTXPort:staticIsDTR( " + port + " )" );
+		log.trace(  "RXTXPort:staticIsDTR( " + port + " )" );
 		return( nativeStaticIsDTR( port ) );
 	}
 	/**
@@ -2002,8 +1820,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public static boolean staticIsRI( String port )
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln(  "RXTXPort:staticIsRI( " + port + " )" );
+		log.trace(  "RXTXPort:staticIsRI( " + port + " )" );
 		return( nativeStaticIsRI( port ) );
 	}
 
@@ -2022,12 +1839,9 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 		throws UnsupportedCommOperationException
 	{
 		byte ret;
-		if ( debug )
-			z.reportln(  "getParityErrorChar()" );
+		log.trace(  "getParityErrorChar()" );
 		ret = nativeGetParityErrorChar();
-		if ( debug )
-			z.reportln(  "getParityErrorChar() returns " +
-						ret );
+		log.trace(  "getParityErrorChar() returns " + ret );
 		return( ret );
 	}
 
@@ -2045,8 +1859,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public boolean setParityErrorChar( byte b )
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln(  "setParityErrorChar(" + b + ")" );
+		log.trace(  "setParityErrorChar(" + b + ")" );
 		return( nativeSetParityErrorChar( b ) );
 	}
 
@@ -2064,12 +1877,9 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 		throws UnsupportedCommOperationException
 	{
 		byte ret;
-		if ( debug )
-			z.reportln(  "getEndOfInputChar()" );
+		log.trace(  "getEndOfInputChar()" );
 		ret = nativeGetEndOfInputChar();
-		if ( debug )
-			z.reportln(  "getEndOfInputChar() returns " +
-						ret );
+		log.trace(  "getEndOfInputChar() returns " + ret );
 		return( ret );
 	}
 
@@ -2085,8 +1895,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public boolean setEndOfInputChar( byte b )
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln(  "setEndOfInputChar(" + b + ")" );
+		log.trace(  "setEndOfInputChar(" + b + ")" );
 		return( nativeSetEndOfInputChar( b ) );
 	}
 
@@ -2104,8 +1913,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public boolean setUARTType(String type, boolean test)
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln(  "RXTXPort:setUARTType()");
+		log.trace(  "RXTXPort:setUARTType()");
 		return nativeSetUartType(type, test);
 	}
 	/**
@@ -2135,8 +1943,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 		throws UnsupportedCommOperationException,
 		IOException
 	{
-		if ( debug )
-			z.reportln(  "RXTXPort:setBaudBase()");
+		log.trace(  "RXTXPort:setBaudBase()");
 		return nativeSetBaudBase(BaudBase);
 	}
 
@@ -2149,8 +1956,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public int getBaudBase() throws UnsupportedCommOperationException,
 		IOException
 	{
-		if ( debug )
-			z.reportln(  "RXTXPort:getBaudBase()");
+		log.trace(  "RXTXPort:getBaudBase()");
 		return nativeGetBaudBase();
 	}
 
@@ -2164,8 +1970,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public boolean setDivisor(int Divisor)
 		throws UnsupportedCommOperationException, IOException
 	{
-		if ( debug )
-			z.reportln(  "RXTXPort:setDivisor()");
+		log.trace(  "RXTXPort:setDivisor()");
 		return nativeSetDivisor(Divisor);
 	}
 
@@ -2178,8 +1983,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public int getDivisor() throws UnsupportedCommOperationException,
 		IOException
 	{
-		if ( debug )
-			z.reportln(  "RXTXPort:getDivisor()");
+		log.trace(  "RXTXPort:getDivisor()");
 		return nativeGetDivisor();
 	}
 
@@ -2191,8 +1995,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 
 	public boolean setLowLatency() throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln(  "RXTXPort:setLowLatency()");
+		log.trace(  "RXTXPort:setLowLatency()");
 		return nativeSetLowLatency();
 	}
 
@@ -2204,8 +2007,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 
 	public boolean getLowLatency() throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln(  "RXTXPort:getLowLatency()");
+		log.trace(  "RXTXPort:getLowLatency()");
 		return nativeGetLowLatency();
 	}
 
@@ -2218,8 +2020,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public boolean setCallOutHangup(boolean NoHup)
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln(  "RXTXPort:setCallOutHangup()");
+		log.trace(  "RXTXPort:setCallOutHangup()");
 		return nativeSetCallOutHangup(NoHup);
 	}
 
@@ -2232,8 +2033,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public boolean getCallOutHangup()
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln(  "RXTXPort:getCallOutHangup()");
+		log.trace(  "RXTXPort:getCallOutHangup()");
 		return nativeGetCallOutHangup();
 	}
 
@@ -2246,8 +2046,7 @@ Documentation is at http://java.sun.com/products/jdk/1.2/docs/api/java/io/InputS
 	public boolean clearCommInput()
 		throws UnsupportedCommOperationException
 	{
-		if ( debug )
-			z.reportln(  "RXTXPort:clearCommInput()");
+		log.trace(  "RXTXPort:clearCommInput()");
 		return nativeClearCommInput();
 	}
 

--- a/src/main/java/gnu/io/Zystem.java
+++ b/src/main/java/gnu/io/Zystem.java
@@ -59,8 +59,13 @@ package gnu.io;
 
 import java.io.RandomAccessFile;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class Zystem
 {
+	private static final Logger log = LoggerFactory.getLogger(Zystem.class);
+
 	public static final int SILENT_MODE	= 0;
 	public static final int FILE_MODE	= 1;
 	public static final int NET_MODE	= 2;
@@ -208,7 +213,7 @@ public class Zystem
 			w.writeBytes( s );
 			w.close();
 		} catch ( Exception e ) {
-			System.out.println("Debug output file write failed");
+			log.error("Debug output file write failed", e);
 		}
 	}
 
@@ -220,7 +225,7 @@ public class Zystem
 		}
 		else if ( mode == PRINT_MODE )
 		{
-			System.out.println( s );
+			log.info( s );
 			return( true );
 		}
 		else if ( mode == MEX_MODE )
@@ -256,7 +261,7 @@ public class Zystem
 		}
 		else if ( mode == PRINT_MODE )
 		{
-			System.out.println( );
+			log.info( "" );
 			return( true );
 		}
 		else if ( mode == MEX_MODE )
@@ -288,7 +293,7 @@ public class Zystem
 		}
 		else if ( mode == PRINT_MODE )
 		{
-			System.out.println( s );
+			log.info( s );
 			return( true );
 		}
 		else if ( mode == MEX_MODE )

--- a/src/main/java/gnu/io/Zystem.java
+++ b/src/main/java/gnu/io/Zystem.java
@@ -225,7 +225,7 @@ public class Zystem
 		}
 		else if ( mode == PRINT_MODE )
 		{
-			log.info( s );
+			log.debug( s );
 			return( true );
 		}
 		else if ( mode == MEX_MODE )
@@ -261,7 +261,7 @@ public class Zystem
 		}
 		else if ( mode == PRINT_MODE )
 		{
-			log.info( "" );
+			log.debug( "" );
 			return( true );
 		}
 		else if ( mode == MEX_MODE )
@@ -293,7 +293,7 @@ public class Zystem
 		}
 		else if ( mode == PRINT_MODE )
 		{
-			log.info( s );
+			log.debug( s );
 			return( true );
 		}
 		else if ( mode == MEX_MODE )

--- a/src/main/java/gnu/io/factory/SerialPortRegistry.java
+++ b/src/main/java/gnu/io/factory/SerialPortRegistry.java
@@ -6,7 +6,11 @@ import java.util.TreeSet;
 
 import gnu.io.SerialPort;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class SerialPortRegistry {
+	private static final Logger log = LoggerFactory.getLogger(SerialPortRegistry.class);
 
 	private Collection<SerialPortCreator<? extends SerialPort>> portCreators;
 	
@@ -57,7 +61,7 @@ public class SerialPortRegistry {
 				if(creator.isApplicable(portName, expectedClass))
 					return (SerialPortCreator<T>) creator;
 			} catch(Exception e) {
-				System.err.println("Error for SerialPortCreator#isApplicable: " + creator.getClass()+"; " + creator.getProtocol() +" -> " + e.getMessage());
+				log.error("Error for SerialPortCreator#isApplicable: " + creator.getClass()+"; " + creator.getProtocol() + " ->", e);
 			}
 		}
 		return null;

--- a/src/main/java/gnu/io/rfc2217/ComPortOptionHandler.java
+++ b/src/main/java/gnu/io/rfc2217/ComPortOptionHandler.java
@@ -57,12 +57,16 @@ package gnu.io.rfc2217;
 
 import org.apache.commons.net.telnet.TelnetOptionHandler;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * RFC 2217 telnet COM-PORT-OPTION.
  *
  * @see <a href="http://tools.ietf.org/html/rfc2217">RFC 2217</a>
  */
 public class ComPortOptionHandler extends TelnetOptionHandler {
+    private static final Logger log = LoggerFactory.getLogger(ComPortOptionHandler.class);
 
     private final TelnetSerialPort port;
 
@@ -88,7 +92,7 @@ public class ComPortOptionHandler extends TelnetOptionHandler {
         try {
             command = RFC2217.decodeComPortCommand(data);
         } catch (IllegalArgumentException e) {
-            System.err.println(this.port.getName() + ": rec'd invalid COM-PORT-OPTION command: " + e.getMessage());
+            log.error(this.port.getName() + ": rec'd invalid COM-PORT-OPTION command:", e);
             return null;
         }
 

--- a/src/main/java/gnu/io/rfc2217/TelnetSerialPort.java
+++ b/src/main/java/gnu/io/rfc2217/TelnetSerialPort.java
@@ -73,6 +73,9 @@ import org.apache.commons.net.telnet.TelnetClient;
 import org.apache.commons.net.telnet.TelnetInputListener;
 import org.apache.commons.net.telnet.TerminalTypeOptionHandler;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static gnu.io.rfc2217.RFC2217.CONTROL_BREAK_OFF;
 import static gnu.io.rfc2217.RFC2217.CONTROL_BREAK_ON;
 import static gnu.io.rfc2217.RFC2217.CONTROL_DTR_OFF;
@@ -150,6 +153,7 @@ import static gnu.io.rfc2217.RFC2217.STOPSIZE_2;
  * @see <a href="http://tools.ietf.org/html/rfc2217">RFC 2217</a>
  */
 public class TelnetSerialPort extends SerialPort {
+    private static final Logger log = LoggerFactory.getLogger(TelnetSerialPort.class);
 
     private static final int DEFAULT_BAUD_RATE = 9600;
 
@@ -896,7 +900,7 @@ public class TelnetSerialPort extends SerialPort {
         try {
             currentListener.serialEvent(event);
         } catch (Exception e) {
-        	System.err.println(this.name + ": exception from listener " + listener + ": " + e.getMessage());
+        	log.error(this.name + ": exception from listener " + listener + ":", e);
         }
     }
 
@@ -908,7 +912,7 @@ public class TelnetSerialPort extends SerialPort {
         try {
             this.telnetClient.sendSubnegotiation(command.getBytes());
         } catch (IOException e) {
-        	System.err.println(this.name + ": exception sending subcommand: " + e.getMessage());
+        	log.error(this.name + ": exception sending subcommand:", e);
         }
     }
 

--- a/test/src/test/NRJavaSerialTest.java
+++ b/test/src/test/NRJavaSerialTest.java
@@ -62,7 +62,11 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import gnu.io.CommPortIdentifier;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class NRJavaSerialTest {
+    private static final Logger log = LoggerFactory.getLogger(NRJavaSerialTest.class);
 
     private static final Lock LOCK = new ReentrantLock();
     private static final String PORT = "/dev/ttyUSB0";
@@ -73,7 +77,7 @@ public class NRJavaSerialTest {
         Thread.sleep(2000L);
         CommPortIdentifier id = CommPortIdentifier.getPortIdentifier(PORT);
         id.open(NRJavaSerialTest.class.getSimpleName(), 5000);
-        System.out.println("Opened: " + PORT);
+        log.info("Opened: " + PORT);
         LOCK.lock();
     }
 
@@ -82,15 +86,14 @@ public class NRJavaSerialTest {
         try {
             for (int i=0;i<5&&!Thread.currentThread().isInterrupted();i++) {
                 Enumeration<CommPortIdentifier> ids = CommPortIdentifier.getPortIdentifiers();
-                System.out.println("--- Port Identifiers ---");
+                log.info("--- Port Identifiers ---");
                 while (ids.hasMoreElements()) {
-                    System.out.println("name: " + ids.nextElement().getName());
+                    log.info("name: " + ids.nextElement().getName());
                 }
-                System.out.println();
                 Thread.sleep(5000L);
             }
         } catch (InterruptedException e) {
-            System.out.println("Thread interrupted");
+            log.error("Thread interrupted");
         }
         System.exit(0);
     }

--- a/test/src/test/ReadTest.java
+++ b/test/src/test/ReadTest.java
@@ -7,12 +7,18 @@ import java.util.TooManyListenersException;
 import gnu.io.NRSerialPort;
 import gnu.io.SerialPortEvent;
 import gnu.io.Zystem;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class ReadTest {
+	private static final Logger log = LoggerFactory.getLogger(ReadTest.class);
+
 	public static void main(String [] args) {
 
 		String port = "";
 		for(String s:NRSerialPort.getAvailableSerialPorts()){
-			System.out.println("Availible port: "+s);
+			log.info("Availible port: "+s);
 			port=s;
 		}
 
@@ -37,7 +43,7 @@ public class ReadTest {
 						e.printStackTrace();
 					}
 				}if(ev.getEventType()==SerialPortEvent.HARDWARE_ERROR) {
-					System.out.println("Clean exit of hardware");
+					log.info("Clean exit of hardware");
 					serial.disconnect();
 				}
 			});


### PR DESCRIPTION
This is a prototype of the functionality suggested in #193. It seems to work well enough. At the beginning of every JNI function, I call a setup macro which pushes a reference to the `JNIEnv` and `jobj` or `jclass` onto a thread-local stack; then I replace the `report_error`/`report_warning`/`report`/`report_verbose` functions with one which retrieves the current JNI context from that stack and uses it to look up and call the appropriate SLF4J logging function.

The result is _very_ noisy. At the default `DEBUG` level of filtering, both Java and native code spam a lot of messages about their internal processes. If you enable `TRACE`-level output, you get a lot of extremely fine-level detail, mostly from `report_verbose()` in the native code. Stuff that no one would care about – like per-byte logging of data read. So even if this branch is already technically sound, I don't think it would be a good idea to cut a release including it until I've demoted more `DEBUG`-level logging statements to `TRACE`, and eliminated lots of the existing `TRACE` logs entirely.

I also want to look into how other libraries which integrate SLF4J keep output sparse and meaningful to downstream consumers, while still having lots of internal logging which is toggled off by default. I know there's got to be some way for libraries to log at higher levels but not spam the application log by default _without_ requiring application developers to explicitly configure filtering of the library packages. Is that what markers are for? Will have to find out.

Note that this branch looks really long because it's based on #189. The work specific to this branch starts at the commit with the message “Use SLF4J for logging in the Java code.” (Currently f9a9596, but likely to change as I continue to work.)