### PR TITLE
Add formatter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-  id "biz.aQute.bnd.builder" version "5.0.1"
+	id "biz.aQute.bnd.builder" version "5.0.1"
+	id "com.diffplug.spotless" version "5.9.0"
 }
 
 apply plugin: 'java'
@@ -59,7 +60,7 @@ jar {
 		"Import-Package": "com.sun.jna.platform.win32;resolution:=optional,org.apache.commons.net.telnet;resolution:=optional,!gnu.io*,*",
 		"Export-Package": "gnu.io*"
 	)
-	
+
 }
 
 task javadocJar(type: Jar) {
@@ -71,6 +72,22 @@ task sourcesJar(type: Jar) {
 	classifier = 'sources'
 	from (sourceSets.main.allSource) {
 		exclude 'native/'
+	}
+}
+
+spotless {
+	format 'misc', {
+		target '*.gradle'
+
+		trimTrailingWhitespace()
+		indentWithTabs()
+		endWithNewline()
+	}
+
+	java {
+		importOrder()
+		removeUnusedImports()
+		eclipse()
 	}
 }
 /*


### PR DESCRIPTION
This adds spotless to the gradle build. The code can be formatted with `gradle spotlessApply`. It uses the Eclipse default formatter, but VSCode integration is also available.

If this is accepted, I will file a follow-up PR to do the formatting and manually check if everything has been formatted as intended. But this should probably be done after #189 and #194 has been merged.

This has been suggested by @MrDOS https://github.com/MrDOS/nrjavaserial/pull/3#pullrequestreview-566800485 and I had it also in my mind.