### PR TITLE
Enable Spotless' ratchetting mode

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,31 @@
+# Our code formatter, Spotless, checks that file line endings match whatever
+# Git thinks they should be. Unfortunately, Git's default thinking is that
+# lines should follow the platform's native line ending: see
+# https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreeol.
+# Git has this thought rattling around in the back of its mind even when
+# automatic line ending convertion (`core.autocrlf`) is turned off (`false`).
+# When Spotless rolls up and asks Git what it thinks on a Windows system, it'll
+# say “CRLF” (assuming the user hasn't overridden `core.eol`), even when all of
+# the checked-out files are LF-terminated. So Spotless will throw an error for
+# every. Single. Line of source.
+#
+# The solution is to tell Git that we want all files (`*`) to be LF-terminated
+# (`eol=lf`), but we don't ever want it to do any conversions automatically
+# (`-text`).
+#
+# Some sources, including Spotless themselves (https://github.com/diffplug/
+# spotless/tree/main/plugin-gradle#line-endings-and-encodings-invisible-stuff),
+# suggest using:
+#
+#     * text eol=lf
+#
+# This forces Git to treat all files (`*`) as text (`text`) with LF-terminated
+# lines (`eol=lf`). This configuration will break any binary files checked into
+# the repository! Git will perform end-of-line mangling – sorry,
+# “normalization” – on checkout of all files it thinks contain text. If it
+# thinks your binary files are text and should have LF-terminated lines, then
+# it'll happily replace all CRLF byte sequences (0x0D0A) with just LF (0x0A).
+#
+# So, to recap: keep line ending conversions disabled, but maintain a correct
+# opinion about what the line endings should be.
+* -text eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         working-directory: src/main/c
 
     steps:
-      - name: Checkout the code
+      - name: Checkout the target branch
         uses: actions/checkout@v2
       - name: Setup Java
         uses: actions/setup-java@v1
@@ -58,7 +58,7 @@ jobs:
         working-directory: src/main/c
 
     steps:
-      - name: Checkout the code
+      - name: Checkout the target branch
         uses: actions/checkout@v2
       - name: Setup Java
         uses: actions/setup-java@v1
@@ -89,7 +89,7 @@ jobs:
         working-directory: src/main/c
 
     steps:
-      - name: Checkout the code
+      - name: Checkout the target branch
         uses: actions/checkout@v2
       - name: Setup Java
         # This feels extremely dirty, but the only native header we care about
@@ -121,7 +121,15 @@ jobs:
       - natives-freebsd
 
     steps:
-      - name: Checkout the code
+      # We use Spotless in “ratchet mode” to incrementally enforce code
+      # formatting throughout the project. In order to ensure feature branches
+      # don't regress formatting when compared with the master branch, we need
+      # to have a local copy of the master branch for comparison.
+      - name: Checkout the master branch
+        uses: actions/checkout@v2
+        with:
+          ref: master
+      - name: Checkout the target branch
         uses: actions/checkout@v2
       - name: Setup Java
         uses: actions/setup-java@v1

--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,8 @@ task sourcesJar(type: Jar) {
 }
 
 spotless {
+	ratchetFrom 'origin/master'
+
 	format 'misc', {
 		target '*.gradle'
 
@@ -132,11 +134,11 @@ uploadArchives {
 			beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
 		repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-		  authentication(userName: ossrhUsername, password: ossrhPassword)
+			authentication(userName: ossrhUsername, password: ossrhPassword)
 		}
-  
+
 		snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-		  authentication(userName: ossrhUsername, password: ossrhPassword)
+			authentication(userName: ossrhUsername, password: ossrhPassword)
 		}
 
 


### PR DESCRIPTION
This way, old errors don't break the build.