### PR TITLE
Disable Spotless on `gradle check` for now

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ task sourcesJar(type: Jar) {
 }
 
 spotless {
+	enforceCheck false
 	ratchetFrom 'origin/master'
 
 	format 'misc', {


### PR DESCRIPTION
I really want to start to use Spotless, and having it run automatically on `gradle check` is part of its magic – but it needs to not cause build failures due to formatting errors in areas which haven't changed. I was hoping ratchetting mode would be sufficient, but that still checks formatting on a whole-file basis. E.g., if a file `Foo.java` was changed, then the _entire_ `Foo.java` is checked for formatting errors, not just the area of the diff. In a project like this where the majority of the source is (currently, lamentably) kept in a couple multi-thousand-line files, you can't sensibly apply formatting fixes on a file-by-file basis along with other changes. It masks the real diff too much. I'm about to open a PR to fix #197; it's +259 -103. But because it touches `RXTXPort.java`, it would be ten times that size if I had to fix the formatting at the same time, and the real changes would be totally buried.

Hopefully I can get a reformatting commit made up soon, and then I'm looking forward to re-enabling Spotless on the check task.