### PR TITLE
Fix FD leak when checking lock dir permissions

### DIFF
--- a/src/main/c/src/SerialImp.c
+++ b/src/main/c/src/SerialImp.c
@@ -5835,7 +5835,7 @@ int check_group_uucp()
 	strcat(testLockAbsFileName, testLockFileDirName);
 	strcat(testLockAbsFileName, "/");
 	strcat(testLockAbsFileName, testLockFileName);
-	if ( 0 == mkstemp(testLockAbsFileName) )
+	if ( 0 == strlen(mktemp(testLockAbsFileName)) )
 	{
 		free(testLockAbsFileName);
 		report_error("check_group_uucp(): mktemp malformed string - \


### PR DESCRIPTION
`mkstemp(3)` creates and opens a file descriptor for a temporary file, but this file descriptor was immediately discarded in favour of
`fopen(3)`'ing the file by name and using that `FILE *` stream. I'm sure whoever originally wrote this code meant to use `mktemp(3)` instead, which only creates a unique file from a template name (equivalent to `mktemp(1)`).

This fixes https://github.com/openhab/openhab-core/issues/1842 and mitigates #111.