### PR TITLE
[issue #229] Prevent Buffer Overflows When Constructing Messages

### DIFF
--- a/src/main/c/include/SerialImp.h
+++ b/src/main/c/include/SerialImp.h
@@ -501,5 +501,4 @@ int check_lock_pid( const char *, int );
 int printj(JNIEnv *env, wchar_t *fmt, ...);
 
 #define UNEXPECTED_LOCK_FILE "RXTX Error:  Unexpected lock file: %s\n Please report to the RXTX developers\n"
-#define LINUX_KERNEL_VERSION_ERROR "\n\n\nRXTX WARNING:  This library was compiled to run with OS release %s and you are currently running OS release %s.  In some cases this can be a problem.  Try recompiling RXTX if you notice strange behavior.  If you just compiled RXTX make sure /usr/include/linux is a symbolic link to the include files that came with the kernel source and not an older copy.\n\n\npress enter to continue\n"
 #define UUCP_ERROR "\n\n\nRXTX WARNING:  This library requires the user running applications to be in\ngroup uucp.  Please consult the INSTALL documentation.  More information is\navaiable under the topic 'How can I use Lock Files with rxtx?'\n" 


### PR DESCRIPTION
- increase buffer sizes
- change sprintf() calls to snprintf() calls introducing respective
maximum size arguments
- remove #if / #endif blocks dealing with system names on Linux
- comment message informing the user that locking worked
- correct variable name and remove unused buffer name[80] in uucp_lock()

It would be great if someone could test this because I'm not a C(++) developer and don't have the toolchains installed.