### PR TITLE
Upgrade commons-net to 3.9.0 to address CVE-2021-37533

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ repositories {
 dependencies {
 	compile fileTree(dir: 'libs', includes: ['*.jar'])
 	testCompile 'junit:junit:4.12'
-	compile 'commons-net:commons-net:3.7.2'
+	compile 'commons-net:commons-net:3.9.0'
 	compileOnly 'net.java.dev.jna:jna:4.4.0'
 	compileOnly 'net.java.dev.jna:jna-platform:4.4.0'
 }


### PR DESCRIPTION
This newer version addresses CVE-2021-37533 which prevents issues for users who use this older version as a transitive nrjavaserial dependency.

For release notes, see:

https://commons.apache.org/proper/commons-net/changes-report.html

Fixes #237