### PR TITLE
Fix segfault if file descriptor unavailable

### DIFF
--- a/src/main/c/src/SerialImp.c
+++ b/src/main/c/src/SerialImp.c
@@ -3081,6 +3081,11 @@ int read_byte_array( JNIEnv *env,
 	struct event_info_struct *eis = ( struct event_info_struct * )
 		get_java_var_long( env, *jobj,"eis","J" );
 
+	if (eis == NULL) {
+		throw_java_exception(env, IO_EXCEPTION, "read_byte_array",
+			"Unable to read byte array");
+		return -1;
+	}
 	report_time_start();
 	flag = eis->eventflags[SPE_DATA_AVAILABLE];
 	eis->eventflags[SPE_DATA_AVAILABLE] = 0;


### PR DESCRIPTION
The `get_java_var_long` function returns 0 in several failure modes, e.g. if [a file descriptor is unavailable](https://github.com/NeuronRobotics/nrjavaserial/blob/0df8b60485a56d7698b71183237b5615d02a8194/src/main/c/src/SerialImp.c#L5137-L5142).

However, one of the call sites is missing the result check, which causes a JVM segfault if the return value is 0. The segfault occurs on [dereferencing the pointer](https://github.com/NeuronRobotics/nrjavaserial/blob/0df8b60485a56d7698b71183237b5615d02a8194/src/main/c/src/SerialImp.c#L3085):

```c
eis->eventflags[SPE_DATA_AVAILABLE]
```

Add a result value check, throwing a proper IOException if it is 0.

See also similar issue #59.

Fixes #112, #136 and #242.
