### PR TITLE
SerialImp.c:RXTXCommDriver(testRead) - fcntl(,F_SETFL, O_RDWR) does not work on Linux

### DIFF
--- a/src/main/c/src/SerialImp.c
+++ b/src/main/c/src/SerialImp.c
@@ -4422,17 +4422,12 @@ JNIEXPORT jboolean  JNICALL RXTXCommDriver(testRead)(
 		//report_warning("\ntestRead(): Attempting to open: ");
 		//report_warning(name);
 		fd=localOpen ( name, O_RDONLY | O_NONBLOCK |O_NOCTTY);
-		int cmd=FD_CLOEXEC|F_SETFL;
 		//report_error("\ntestRead(): Setting ownership flags");
 		ret= fcntl(fd,F_SETOWN,getpid());
 		//report_error( strerror(errno) );
 
 		//report_error("\ntestRead(): Forcing unlock flags");
 		ret = fcntl(fd,F_UNLCK);
-		//report_error( strerror(errno) );
-
-		//report_error("\ntestRead(): Setting read/write flags");
-		ret= fcntl(fd,cmd,O_RDWR | O_NOCTTY | O_NONBLOCK);
 		//report_error( strerror(errno) );
 #else
 		fd=localOpen ( name, O_RDWR | O_NOCTTY | O_NONBLOCK );


### PR DESCRIPTION
On linux F_SETFL cannot change O_RDONLY, O_WRONLY, O_RDWR - https://man7.org/linux/man-pages/man2/F_GETFL.2const.html.

FD_CLOEXEC is supposed to be altered by F_SETFD, not by F_SETFL - https://man7.org/linux/man-pages/man2/f_setfd.2const.html and it is not a command by its own (second parameter of fctnl) but a parameter (third parameter of fctnl)).

Actually the definitions in /usr/include/bits/fcntl-linux.h are:
```c
#define FD_CLOEXEC        1       /* Actually anything with low bit set goes */
#define F_GETFD           1       /* Get file descriptor flags.  */
```
so
```
int cmd=FD_CLOEXEC|F_SETFL;
ret= fcntl(fd,cmd,O_RDWR | O_NOCTTY | O_NONBLOCK);
```
was doing
```c
ret= fcntl(fd, F_GETFD | F_SETFL ,O_RDWR | O_NOCTTY | O_NONBLOCK);
```