### PR TITLE
SerialImp.c:configure_port: for hidraw devices tcgetattr failure is OK

### DIFF
--- a/src/main/c/src/SerialImp.c
+++ b/src/main/c/src/SerialImp.c
@@ -373,7 +373,10 @@ int configure_port( int fd )
 
 	if( fd < 0 ) goto fail;
 
-	if( tcgetattr( fd, &ttyset ) < 0 ) goto fail;
+	if( tcgetattr( fd, &ttyset ) < 0 ) {
+		if (errno == EINVAL || errno == ENOTTY) return 0;
+		goto fail;
+	}
 	ttyset.c_iflag = INPCK;
 	ttyset.c_lflag = 0;
 	ttyset.c_oflag = 0;


### PR DESCRIPTION
Before this change the error message for opening /dev/hidraw0 was:
```java
CommPortIdentifier id = CommPortIdentifier.getPortIdentifier("/dev/hidraw0");
id.open(NRJavaSerialTest.class.getSimpleName(), 5000);
```
→
```
Port /dev/hidraw0 in use by another application
Exception in thread "main" gnu.io.PortInUseException: Unknown Owner
        at gnu.io.CommPortIdentifier.open(CommPortIdentifier.java:476)
        at test.NRJavaSerialTest.main(NRJavaSerialTest.java:86)
```