### PR TITLE
SerialImp.c:RXTXPort(open) - avoid noop fcntl() and pointless assignments

### DIFF
--- a/src/main/c/src/SerialImp.c
+++ b/src/main/c/src/SerialImp.c
@@ -713,17 +713,12 @@ JNIEXPORT jint JNICALL RXTXPort(open)(
        See tty(4) ("man 4 tty") and ioctl(2) ("man 2 ioctl") for details.
        */
 #if defined(__linux__)
-			int ret;
 			//report_error("\nnative open(): Setting ownership flags");
-			ret= fcntl(fd,F_SETOWN,getpid());
+			fcntl(fd,F_SETOWN,getpid());
 			//report_error( strerror(errno) );
 
 			//report_error("\nnativec(): Forcing unlock flags");
-			ret = fcntl(fd,F_UNLCK);
-			//report_error( strerror(errno) );
-
-			//report_error("\nnative open(): Setting read/write flags");
-			ret= fcntl(fd,F_SETFL,O_CLOEXEC|O_RDWR|O_NONBLOCK);
+			fcntl(fd,F_UNLCK);
 			//report_error( strerror(errno) );
 #endif
        if (fd >= 0 && (ioctl(fd, TIOCEXCL) == -1))


### PR DESCRIPTION
The file is already opened with O_RDWR | O_NOCTTY | O_NONBLOCK.

* O_RDWR cannot be changed on linux with F_SETFL - https://man7.org/linux/man-pages/man2/F_GETFL.2const.html
* The last page lists explicitly what can be changed by F_SETFL and O_NOCTTY is not mentioned.
* O_NONBLOCK is already set when opening the file
* FD_CLOEXEC is supposed to be set with F_SETFD - https://man7.org/linux/man-pages/man2/F_SETFD.2const.html

* remove pointless assignments

