### PR TITLE
SerialImp.c:RXTXCommDriver(testRead) - ignore tcgetattr() failures for hidraw device

### DIFF
--- a/src/main/c/src/SerialImp.c
+++ b/src/main/c/src/SerialImp.c
@@ -4458,15 +4458,16 @@ JNIEXPORT jboolean  JNICALL RXTXCommDriver(testRead)(
 		int saved_flags;
 		struct termios saved_termios;
 
-		if (tcgetattr(fd, &ttyset) < 0) {
-			ret = JNI_FALSE;
-			goto END;
-		}
-
 		/* save, restore later */
 		if ( ( saved_flags = fcntl(fd, F_GETFL ) ) < 0 )
 		{
 			report_warning( "testRead() fcntl(F_GETFL) failed\n" );
+			ret = JNI_FALSE;
+			goto END;
+		}
+
+		if (tcgetattr(fd, &ttyset) < 0) {
+			if (errno == EINVAL || errno == ENOTTY) goto NOT_TERMINAL;
 			ret = JNI_FALSE;
 			goto END;
 		}
@@ -4490,7 +4491,7 @@ JNIEXPORT jboolean  JNICALL RXTXCommDriver(testRead)(
 			tcsetattr( fd, TCSANOW, &saved_termios );
 			goto END;
 		}
-
+NOT_TERMINAL:
 /*
 
               The following may mess up if both EAGAIN and EWOULDBLOCK


### PR DESCRIPTION
If `tcgetattr(fd, &ttyset)` fails and errno is EINVAL 22 Invalid Argument, or ENOTTY - https://en.wikipedia.org/wiki/Not_a_typewriter, then this is not a serial device and do not try to adjust its settings.

First obtain the flags, so that these can be restored later.

Why EINVAL and not only ENOTTY? - It should be ENOTTY but is EINVAL : https://lore.kernel.org/linux-input/24eaed9105633d03eded13e11c5a994bd93a81aa.camel@aegee.org/.